### PR TITLE
Added annotations doc

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -39,6 +39,26 @@ pre {
   background-color: #232323 !important;
 }
 
+.error, .warning, .info, .success	{
+	border-left: 5px solid #FD0;
+	padding: 10px 15px;
+	margin-left: -20px;
+	margin-right: -15px;
+	background-color: #FAFAFA;
+	border-radius: 2px;
+}
+
+.info {
+	border-color: #56ADEC;
+}
+
+body .prose blockquote {
+  border-left: 5px solid #56ADEC;
+	background-color: #FAFAFA;
+	border-radius: 2px;
+  word-wrap: break-word;
+}
+
 .toc {
   list-style-type: none;
   color: #ffffff;

--- a/package.json
+++ b/package.json
@@ -11,12 +11,16 @@
     "build": "gatsby build --prefix-links",
     "deploy": "gatsby build --prefix-links && gh-pages -a -d public -b mb-pages",
     "develop": "gatsby develop",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run test-text",
+    "test-text": "retext-mapbox-standard pages"
   },
   "author": "Cameron Mace",
   "license": "ISC",
   "devDependencies": {
     "gh-pages": "^0.12.0"
+  },
+  "devDependencies": {
+    "retext-mapbox-standard": "^2.0.0"
   },
   "dependencies": {
     "babel-preset-es2015": "^6.3.13",

--- a/pages/map-sdk/5.0.0/getting_started.md
+++ b/pages/map-sdk/5.0.0/getting_started.md
@@ -5,7 +5,7 @@ path: /map-sdk/5.0.0/getting-started/
 
 ## Introduction
 
-The Mapbox Maps SDK is an open source toolset for displaying maps inside your application. A demo app is available on the Google Play Store that includes an abundance of examples, including the ones referenced throughout this documentation.
+The Mapbox Maps SDK is an open source toolset for displaying maps inside your application. A demo app is available on the Google Play Store that includes a bunch of examples, including the ones referenced throughout this documentation.
 
 ### Support and contributions
 
@@ -15,12 +15,12 @@ The Mapbox Maps SDK is an open source toolset for displaying maps inside your ap
 - If you want to contribute, look over our contribution guild lines and open a pull request with your changes.
 
 ### API reference
-All public methods in the Maps SDK project are well documented and can be either viewed inside the source code or directly on the Javadoc (linked below). If you are using a older version of the SDK, you can still access the Javadoc simply by replacing the URL's version number to the one you are using inside your application.
+All public methods in the Maps SDK project are well documented and can be either viewed inside the source code or directly on the Javadoc (linked below). If you are using a older version of the SDK, you can still access the Javadoc by replacing the URL's version number to the one you are using inside your application.
 
 - [5.0.0 Maps SDK Javadoc](https://www.mapbox.com/android-docs/api/map-sdk/5.0.0/index.html)
 
 ### Access tokens
-An access token is necessary to use the Maps SDK. Your access tokens can be managed in [your account settings](https://www.mapbox.com/account/apps/), where you can retrieve current tokens and generate new ones. You should create a new token for each of your apps, which will help you track usage and minimize disruption in the event a token needs to be revoked.
+An access token is necessary to use the Maps SDK. Your access tokens can be managed in [your account settings](https://www.mapbox.com/account/apps/), where you can retrieve current tokens and generate new ones. You should create a new token for each of your apps, which will help you track usage and decrease disruption in the event a token needs to be revoked.
 
 You'll want to place the access token inside your application object inside the `onCreate()` method. To learn more about access tokens, read [this document](https://www.mapbox.com/help/create-api-access-token/).
 
@@ -38,11 +38,11 @@ public class MyApplication extends Application {
 ```
 
 ## Installation
-To start developing your application using the Maps SDK, a few simple steps must be taken before beginning. Note that while we should how to add the stable version of the SDK inside your project, you can also use the nightly build/snapshot or the beta version, if one is available. The dependency given below can be found on MavenCentral.
+To start developing your application using the Maps SDK, a few steps must be taken before beginning. Note that while we should how to add the stable version of the SDK inside your project, you can also use the nightly build/snapshot or the beta version, if one is available. The dependency given below can be found on MavenCentral.
 
 1. Start Android Studio
 2. Open up your applications `build.gradle`
-3. Ensure your projects `minSdkVersion` is at API 15 or higher
+3. Make sure your projects `minSdkVersion` is at API 15 or higher
 4. Under dependencies add a new build rule for the latest mapbox-android-sdk
 5. Click the Sync Project with Gradle Files near the toolbar in Studio
 
@@ -61,7 +61,7 @@ dependencies {
 ```
 
 ### Permissions
-Starting in 5.0, we are making use of the Manifest merge feature which reduces the need to include any Maps SDK required things inside your application's manifest file. If you plan to display the users location on the map or acquire user location information you'll need to include either the Fine or Coarse location permission. The user location permission should also be checked during runtime using the PermissionManager.
+Starting in 5.0, we are making use of the Manifest merge feature which reduces the need to include any Maps SDK required things inside your application's manifest file. If you plan to display the users location on the map or get user location information you'll need to include either the Fine or Coarse location permission. The user location permission should also be checked during runtime using the PermissionManager.
 
 ```xml
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/pages/map-sdk/5.0.1/annotations.md
+++ b/pages/map-sdk/5.0.1/annotations.md
@@ -21,10 +21,10 @@ If you have an abundance of markers or are loading in them from a GeoJSON file, 
 > **Note:** If you want more control over the behavior of a marker, you can use either the MarkerView API which extends a typical Android view or create a symbol layer using runtime styling.
 
 ### Removing markers
-The Mapbox Android SDK comes with two methods for removing markers. to remove a specific marker, use `mapboxMap.removeMarker()` passing in the marker object to be removed. If you instead would like to remove all markers, call the `mapboxMap.clear()` method. Note that this will also remove any polylines and polygons you’ve added to your map.
+The Mapbox Android SDK comes with two methods for removing markers. If you'd like to remove a specific marker, use `mapboxMap.removeMarker()` passing in the marker object to be removed. If you instead would like to remove all markers, call the `mapboxMap.clear()` method. Note that this will also remove any polylines and polygons you’ve added to your map.
 
 ### Customize marker icon
-You can specify a custom icon by using the IconFactory object and passing it to the marker. If you don’t specify an icon, your marker will be given the default marker icon. The anchoring of the marker will be in the center, meaning if you have a icon with a point, you'll need to add padding to the bottom of the image.
+You can specify a custom icon by using the `IconFactory` object and passing it to the marker. If you don’t specify an icon while creating your marker, it will be given the default marker icon. The anchoring of the marker will be in the center, meaning if you have an icon with a point, you'll need to add padding to the bottom of the image.
 
 Place your custom marker image in your project’s drawable folder and note its file name. In the example below, the custom icon’s image file is named blue_marker.png
 
@@ -40,9 +40,9 @@ mapboxMap.addMarker(new MarkerViewOptions()
 ```
 
 ### Capturing marker events
-The Maps SDK provides a handy listener for capturing when a user taps on the marker. By default, all markers come with an onMarkerClick event listener for displaying and hiding info windows. You can override this default event listener and set your own with the setOnMarkerClickListener method.
+The Maps SDK provides a handy listener for capturing when a user taps on the marker. By default, all markers come with an onMarkerClick event listener for displaying and hiding info windows. You can override this default event listener and set your own with the `setOnMarkerClickListener` method.
 
-To display a toast message with the clicked marker’s title, listen for a click event with setOnMarkerClickListener, then call Toast.makeText(). To prevent displaying a toast message and an info window at the same time, return true at the end:
+To display a toast message with the clicked marker’s title, listen for a click event with `setOnMarkerClickListener`, then call `Toast.makeText()`. To prevent displaying a toast message and an info window at the same time, return true at the end:
 
 ```java
 mapboxMap.setOnMarkerClickListener(new MapboxMap.OnMarkerClickListener() {
@@ -55,7 +55,7 @@ mapboxMap.setOnMarkerClickListener(new MapboxMap.OnMarkerClickListener() {
 ```
 
 ### Update a marker
-If you have intentions to update a marker rather then completely remove it, the SDK provides a few update methods which means less boilerplate code and an increase in performance since you are only updating the marker. Using these update APIs, you are able to create animating markers using a [ValueAnimator](https://developer.android.com/reference/android/animation/ValueAnimator.html) for example. The APIs for updating either the marker position or icon bitmap can be found inside your marker object reference.
+If you have intentions to update a marker rather than completely remove it, the SDK provides a few update methods which means less boilerplate code and an increase in performance since you are only updating the marker. Using these update APIs, you are able to create animating markers using a [ValueAnimator](https://developer.android.com/reference/android/animation/ValueAnimator.html) for example. The APIs for updating either the marker position or icon bitmap can be found inside your marker object reference.
 
 ```java
 // Change the marker location
@@ -69,7 +69,7 @@ marker.setIcon(icon);
 Info windows are used to display information in a popup window anchored to a marker. Their default behavior is to display when the marker is tapped, displaying a title textview above a snippet textview. An info window is automatically created if you provide a given marker with either a title or a snippet of text. This process is done when first creating the marker object but once built, you are able to update the info window information by using `marker.setTitle()` for example.
 
 ### Custom view
-The Maps SDK also provides an api to customize the contents and design of info windows. you'll need to create an implementation of the InfoWindowAdapter and then call `MapboxMap.setInfoWindowAdapter()` passing in your implementation as a parameter. One method is given inside the InfoWindowAdapter called `getInfoWindow` which gives the attached marker object and returns the info window view.
+The Maps SDK also provides an api to customize the contents and design of info windows. You'll need to create an implementation of the `InfoWindowAdapter` and then call `MapboxMap.setInfoWindowAdapter()` passing in your implementation as a parameter. One method is given inside the `InfoWindowAdapter` called `getInfoWindow` which gives the attached marker object and returns the info window view.
 
 ## Polyline and Polygons
 Adding a line or polygon to your map is similar to how adding a marker is added. Due to the nature of these object, different APIs are exposed such as polygon color or line width. Instead of taking in a single position, it's required to first bundle all your LatLng's inside a List and then pass them in using the `addAll()` API.

--- a/pages/map-sdk/5.0.1/annotations.md
+++ b/pages/map-sdk/5.0.1/annotations.md
@@ -6,7 +6,7 @@ path: /map-sdk/5.0.1/annotations/
 If you are including a Mapbox map inside your application, chances are that you'd want to add annotations. Annotations are objects drawn either on top of the map or in some cases, within the map itself. These annotations vary from markers to lines and polygons. This document walks through adding the high level objects, if you'd like more control over annotations, make sure to checkout the runtime styling documentation.
 
 ## Markers
-Markers are useful when identifying a single point on the map. The SDK comes with a default marker icon which can be configured to fit your specific needs. APIs are exposed to optionally change this icon to any bitmap image you desire. To create a marker for you map, you are only required to provide a `LatLng` position which defines where the marker will be placed on the map. To actually add the marker to the map, you'll need to call `mapboxMap.addMarker()`.
+Markers are useful when identifying a single point on the map. The SDK comes with a default marker icon which can be configured to fit your specific needs. APIs are exposed to optionally change this icon to any bitmap image you wish. To create a marker for you map, you are only required to provide a `LatLng` position which defines where the marker will be placed on the map. To actually add the marker to the map, you'll need to call `mapboxMap.addMarker()`.
 
 ```java
 mapboxMap.addMarker(new MarkerOptions()
@@ -14,9 +14,9 @@ mapboxMap.addMarker(new MarkerOptions()
   .title("Eiffel Tower")
   );
 ```
-In addition to providing the position, you can also add a title and snippet which are displayed inside an [info window](#info-window). The info window will be displayed when the user taps on the marker and closed when they tap outside the info window.
+Besides providing the position, you can also add a title and snippet which are displayed inside an [info window](#info-window). The info window will be displayed when the user taps on the marker and closed when they tap outside the info window.
 
-If you have an abundance of markers or are loading in them from a GeoJSON file, you can directly add a list of markers using `mapboxMap.addMarkers()`.
+If you have many markers or are loading in them from a GeoJSON file, you can directly add a list of markers using `mapboxMap.addMarkers()`.
 
 > **Note:** If you want more control over the behavior of a marker, you can use either the MarkerView API which extends a typical Android view or create a symbol layer using runtime styling.
 
@@ -69,10 +69,10 @@ marker.setIcon(icon);
 Info windows are used to display information in a popup window anchored to a marker. Their default behavior is to display when the marker is tapped, displaying a title textview above a snippet textview. An info window is automatically created if you provide a given marker with either a title or a snippet of text. This process is done when first creating the marker object but once built, you are able to update the info window information by using `marker.setTitle()` for example.
 
 ### Custom view
-The Maps SDK also provides an api to customize the contents and design of info windows. You'll need to create an implementation of the `InfoWindowAdapter` and then call `MapboxMap.setInfoWindowAdapter()` passing in your implementation as a parameter. One method is given inside the `InfoWindowAdapter` called `getInfoWindow` which gives the attached marker object and returns the info window view.
+The Maps SDK also provides an API to customize the contents and design of info windows. You'll need to create an implementation of the `InfoWindowAdapter` and then call `MapboxMap.setInfoWindowAdapter()` passing in your implementation as a parameter. One method is given inside the `InfoWindowAdapter` called `getInfoWindow` which gives the attached marker object and returns the info window view.
 
 ## Polyline and Polygons
-Adding a line or polygon to your map is similar to how adding a marker is added. Due to the nature of these object, different APIs are exposed such as polygon color or line width. Instead of taking in a single position, it's required to first bundle all your LatLng's inside a List and then pass them in using the `addAll()` API.
+Adding a line or polygon to your map is like how adding a marker is added. Due to the nature of these object, different APIs are exposed such as polygon color or line width. Instead of taking in a single position, it's required to first bundle all your LatLng's inside a List and then pass them in using the `addAll()` API.
 
 ```java
 // Draw polyline on the map

--- a/pages/map-sdk/5.0.1/annotations.md
+++ b/pages/map-sdk/5.0.1/annotations.md
@@ -1,0 +1,88 @@
+---
+title: Annotations
+path: /map-sdk/5.0.1/annotations/
+---
+
+If you are including a Mapbox map inside your application, chances are that you'd want to add annotations. Annotations are objects drawn either on top of the map or in some cases, within the map itself. These annotations vary from markers to lines and polygons. This document walks through adding the high level objects, if you'd like more control over annotations, make sure to checkout the runtime styling documentation.
+
+## Markers
+Markers are useful when identifying a single point on the map. The SDK comes with a default marker icon which can be configured to fit your specific needs. APIs are exposed to optionally change this icon to any bitmap image you desire. To create a marker for you map, you are only required to provide a `LatLng` position which defines where the marker will be placed on the map. To actually add the marker to the map, you'll need to call `mapboxMap.addMarker()`.
+
+```java
+mapboxMap.addMarker(new MarkerOptions()
+  .position(new LatLng(48.85819, 2.29458))
+  .title("Eiffel Tower")
+  );
+```
+In addition to providing the position, you can also add a title and snippet which are displayed inside an [info window](#info-window). The info window will be displayed when the user taps on the marker and closed when they tap outside the info window.
+
+If you have an abundance of markers or are loading in them from a GeoJSON file, you can directly add a list of markers using `mapboxMap.addMarkers()`.
+
+> **Note:** If you want more control over the behavior of a marker, you can use either the MarkerView API which extends a typical Android view or create a symbol layer using runtime styling.
+
+### Removing markers
+The Mapbox Android SDK comes with two methods for removing markers. to remove a specific marker, use `mapboxMap.removeMarker()` passing in the marker object to be removed. If you instead would like to remove all markers, call the `mapboxMap.clear()` method. Note that this will also remove any polylines and polygons you’ve added to your map.
+
+### Customize marker icon
+You can specify a custom icon by using the IconFactory object and passing it to the marker. If you don’t specify an icon, your marker will be given the default marker icon. The anchoring of the marker will be in the center, meaning if you have a icon with a point, you'll need to add padding to the bottom of the image.
+
+Place your custom marker image in your project’s drawable folder and note its file name. In the example below, the custom icon’s image file is named blue_marker.png
+
+```java
+// Create an Icon object for the marker to use
+IconFactory iconFactory = IconFactory.getInstance(MainActivity.this);
+Icon icon = iconFactory.fromResource(R.drawable.blue_marker);
+
+// Add the marker to the map
+mapboxMap.addMarker(new MarkerViewOptions()
+  .position(new LatLng(-37.821648, 144.978594))
+  .icon(icon));
+```
+
+### Capturing marker events
+The Maps SDK provides a handy listener for capturing when a user taps on the marker. By default, all markers come with an onMarkerClick event listener for displaying and hiding info windows. You can override this default event listener and set your own with the setOnMarkerClickListener method.
+
+To display a toast message with the clicked marker’s title, listen for a click event with setOnMarkerClickListener, then call Toast.makeText(). To prevent displaying a toast message and an info window at the same time, return true at the end:
+
+```java
+mapboxMap.setOnMarkerClickListener(new MapboxMap.OnMarkerClickListener() {
+  @Override
+  public boolean onMarkerClick(@NonNull Marker marker) {
+    Toast.makeText(MainActivity.this, marker.getTitle(), Toast.LENGTH_LONG).show();
+    return true;
+  }
+});
+```
+
+### Update a marker
+If you have intentions to update a marker rather then completely remove it, the SDK provides a few update methods which means less boilerplate code and an increase in performance since you are only updating the marker. Using these update APIs, you are able to create animating markers using a [ValueAnimator](https://developer.android.com/reference/android/animation/ValueAnimator.html) for example. The APIs for updating either the marker position or icon bitmap can be found inside your marker object reference.
+
+```java
+// Change the marker location
+marker.setPosition(new LatLng(-37.822884, 144.981916));
+
+// Update the marker icon
+marker.setIcon(icon);
+```
+
+## Info Window
+Info windows are used to display information in a popup window anchored to a marker. Their default behavior is to display when the marker is tapped, displaying a title textview above a snippet textview. An info window is automatically created if you provide a given marker with either a title or a snippet of text. This process is done when first creating the marker object but once built, you are able to update the info window information by using `marker.setTitle()` for example.
+
+### Custom view
+The Maps SDK also provides an api to customize the contents and design of info windows. you'll need to create an implementation of the InfoWindowAdapter and then call `MapboxMap.setInfoWindowAdapter()` passing in your implementation as a parameter. One method is given inside the InfoWindowAdapter called `getInfoWindow` which gives the attached marker object and returns the info window view.
+
+## Polyline and Polygons
+Adding a line or polygon to your map is similar to how adding a marker is added. Due to the nature of these object, different APIs are exposed such as polygon color or line width. Instead of taking in a single position, it's required to first bundle all your LatLng's inside a List and then pass them in using the `addAll()` API.
+
+```java
+// Draw polyline on the map
+mapboxMap.addPolyline(new PolylineOptions()
+  .addAll(points)
+  .color(Color.parseColor("#3bb2d0"))
+  .width(2));
+
+// Draw a polygon on the map
+mapboxMap.addPolygon(new PolygonOptions()
+  .addAll(polygon)
+  .fillColor(Color.parseColor("#3bb2d0")));
+```

--- a/pages/map-sdk/5.0.1/getting_started.md
+++ b/pages/map-sdk/5.0.1/getting_started.md
@@ -3,7 +3,7 @@ title: Map SDK
 path: /map-sdk/5.0.1/getting-started/
 ---
 
-The Mapbox Maps SDK is an open source toolset for displaying maps inside your application. A demo app is available on the Google Play Store that includes an abundance of examples, including the ones referenced throughout this documentation.
+The Mapbox Maps SDK is an open source toolset for displaying maps inside your application. A demo app is available on the Google Play Store that includes a bunch of examples, including the ones referenced throughout this documentation.
 
 ### Support and contributions
 
@@ -13,12 +13,12 @@ The Mapbox Maps SDK is an open source toolset for displaying maps inside your ap
 - If you want to contribute, look over our contribution guild lines and open a pull request with your changes.
 
 ### API reference
-All public methods in the Maps SDK project are well documented and can be either viewed inside the source code or directly on the Javadoc (linked below). If you are using a older version of the SDK, you can still access the Javadoc simply by replacing the URL's version number to the one you are using inside your application.
+All public methods in the Maps SDK project are well documented and can be either viewed inside the source code or directly on the Javadoc (linked below). If you are using a older version of the SDK, you can still access the Javadoc by replacing the URL's version number to the one you are using inside your application.
 
 - [5.0.1 Maps SDK Javadoc](https://www.mapbox.com/android-docs/api/map-sdk/5.0.1/index.html)
 
 ### Access tokens
-An access token is necessary to use the Maps SDK. Your access tokens can be managed in [your account settings](https://www.mapbox.com/account/apps/), where you can retrieve current tokens and generate new ones. You should create a new token for each of your apps, which will help you track usage and minimize disruption in the event a token needs to be revoked.
+An access token is necessary to use the Maps SDK. Your access tokens can be managed in [your account settings](https://www.mapbox.com/account/apps/), where you can retrieve current tokens and generate new ones. You should create a new token for each of your apps, which will help you track usage and decrease disruption in the event a token needs to be revoked.
 
 You'll want to place the access token inside your application object inside the `onCreate()` method. To learn more about access tokens, read [this document](https://www.mapbox.com/help/create-api-access-token/).
 
@@ -36,11 +36,11 @@ public class MyApplication extends Application {
 ```
 
 ## Installation
-To start developing your application using the Maps SDK, a few simple steps must be taken before beginning. Note that while we should how to add the stable version of the SDK inside your project, you can also use the nightly build/snapshot or the beta version, if one is available. The dependency given below can be found on MavenCentral.
+To start developing your application using the Maps SDK, a few steps must be taken before beginning. Note that while we should how to add the stable version of the SDK inside your project, you can also use the nightly build/snapshot or the beta version, if one is available. The dependency given below can be found on MavenCentral.
 
 1. Start Android Studio
 2. Open up your applications `build.gradle`
-3. Ensure your projects `minSdkVersion` is at API 15 or higher
+3. Make sure your projects `minSdkVersion` is at API 15 or higher
 4. Under dependencies add a new build rule for the latest mapbox-android-sdk
 5. Click the Sync Project with Gradle Files near the toolbar in Studio
 
@@ -59,7 +59,7 @@ dependencies {
 ```
 
 ### Permissions
-Starting in 5.0, we are making use of the Manifest merge feature which reduces the need to include any Maps SDK required things inside your application's manifest file. If you plan to display the users location on the map or acquire user location information you'll need to include either the Fine or Coarse location permission. The user location permission should also be checked during runtime using the PermissionManager.
+Starting in 5.0, we are making use of the Manifest merge feature which reduces the need to include any Maps SDK required things inside your application's manifest file. If you plan to display the users location on the map or get user location information you'll need to include either the Fine or Coarse location permission. The user location permission should also be checked during runtime using the PermissionManager.
 
 ```xml
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/pages/map-sdk/5.0.1/getting_started.md
+++ b/pages/map-sdk/5.0.1/getting_started.md
@@ -3,8 +3,6 @@ title: Map SDK
 path: /map-sdk/5.0.1/getting-started/
 ---
 
-## Introduction
-
 The Mapbox Maps SDK is an open source toolset for displaying maps inside your application. A demo app is available on the Google Play Store that includes an abundance of examples, including the ones referenced throughout this documentation.
 
 ### Support and contributions

--- a/pages/map-sdk/_pages.yaml
+++ b/pages/map-sdk/_pages.yaml
@@ -1,1 +1,2 @@
 - "/map-sdk/5.0.1/getting-started/"
+- "/map-sdk/5.0.1/annotations/"

--- a/pages/mapbox-services/2.0.0/geocoder.md
+++ b/pages/mapbox-services/2.0.0/geocoder.md
@@ -22,7 +22,7 @@ MapboxGeocoding mapboxGeocoding = new MapboxGeocoding.Builder()
 ```
 
 ### Geocoding response
-Once you have built your MapboxGeocoding object with all the parameters you'd like to use in the request, you'll need to asynchronously send the request using enqueueCall. Once the request receives a response it will notify the Callback where you can handle the response appropriately.
+Once you have built your MapboxGeocoding object with all the parameters you'd like to use in the request, you'll need to asynchronously send the request using enqueueCall. Once the request receives a response it will tell the Callback where you can handle the response appropriately.
 
 > **Note:** incase your user leaves the activity or application before the callback's notified, you should use `mapboxGeocoding.cancelCall()` within your onDestroy lifecycle method.
 
@@ -49,9 +49,9 @@ mapboxGeocoding.enqueueCall(new Callback<GeocodingResponse>() {
 ```
 
 ### Reverse geocoding
-The process of turning a string address to a coordinate is called reverse geocoding. Instead of supplying the builder with a string address you'd pass in coordinates instead. Handling the response is similar to forward geocoding. While one coordinate is given, you'll oftentimes get multiple results from the response all valid ways to describe to specific location. For example, one might be the street name while another result will be the country. The ordering of the list usually goes from most relevant to least.
+The process of turning a string address to a coordinate is called reverse geocoding. Instead of supplying the builder with a string address you'd pass in coordinates instead. Handling the response is like forward geocoding. While one coordinate is given, you'll oftentimes get multiple results from the response all valid ways to describe to specific location. For example, one might be the street name while another result will be the country. The ordering of the list usually goes from most relevant to least.
 
-You can narrow the response similar to forward geocoding by biasing the result using the available parameters provided in the builder.
+You can narrow the response like forward geocoding by biasing the result using the available parameters provided in the builder.
 
 ```java
 MapboxGeocoding reverseGeocode = new MapboxGeocoding.Builder()
@@ -65,7 +65,7 @@ MapboxGeocoding reverseGeocode = new MapboxGeocoding.Builder()
 ### Android widgets
 In the geocoding examples above, we have been performing request to the API by directly using the builder, making the call, and then handling the response. The Android widgets found in the mapbox-android-ui module make the process of geocoding a bit easier by offering basic widgets.
 
-For forward geocoding, the AutoCompleteWidget is offered. It provides a search box with support for autocomplete results. When the user clicks a result, `onFeatureClick`'s invoked and you can get the addresses coordinates and handle them accordingly.
+For forward geocoding, the AutoCompleteWidget is offered. It provides a search box with support for autocomplete results. When the user clicks a result, `onFeatureClick`'s invoked and you can get the addresses coordinates and handle them.
 
 <!-- TODO link Example -->
 ```xml

--- a/pages/mapbox-services/2.0.0/getting_started.md
+++ b/pages/mapbox-services/2.0.0/getting_started.md
@@ -16,7 +16,7 @@ Mapbox Java is an open source toolset for building applications that need naviga
 - If you want to contribute, look over our contribution guild lines and open a pull request with your changes.
 
 ### API reference
-All public methods in all the project modules are well documented and even include a since tag so you can determine when an API was first added. A link for all the module javadoc pages can be found in the list below:
+All public methods in all the project modules are well documented and even include a since tag so you can find when an API was first added. A link for all the module javadoc pages can be found in the list below:
 
 - [mapbox-java-core](https://www.mapbox.com/android-docs/api/mapbox-java/libjava-core/2.0.0/index.html)
 - [mapbox-java-geojson](https://www.mapbox.com/android-docs/api/mapbox-java/libjava-geojson/2.0.0/index.html)
@@ -30,11 +30,11 @@ All public methods in all the project modules are well documented and even inclu
 If you plan to use any of our APIs such as directions, geocoding, navigation, etc. you'll need to have a Mapbox access token which you'll pass in as a parameter. An access token isn't needed if you plan to use Mapbox Java only for GeoJSON parsing, or Turf calculations. To learn more about access tokens, read [this document](https://www.mapbox.com/help/create-api-access-token/).
 
 ### Position and Point objects
-Throughout the APIs exposed within Mapbox-Java you'll notice the Position object's used heavily representing a coordinate. The order in which the coordinate pair are longitude followed by latitude. Creating a new Position is fairly straight forward and can easily be converted from a LatLng object if you are using our Maps SDK.
+Throughout the APIs exposed within Mapbox-Java you'll notice the Position object's used heavily representing a coordinate. The order in which the coordinate pair are longitude followed by latitude. Creating a new Position is fairly straight forward and can be converted from a LatLng object if you are using our Maps SDK.
 
-The SDK will attempt to detect if your coordinates are outside the excepted range and log a warning. This range is between -180 to 180 for longitudes and -90 to 90 for latitude.
+The SDK will try to detect if your coordinates are outside the excepted range and log a warning. This range is between -180 to 180 for longitudes and -90 to 90 for latitude.
 
-> **Note:** if you happen to be using our Maps SDK in addition to this SDK, you'll notice that the LatLng object has the reverse order, latitude comes before the longitude value.
+> **Note:** if you happen to be using our Maps SDK with this SDK, you'll notice that the LatLng object has the reverse order, latitude comes before the longitude value.
 
 Point will also be found in this SDK which is used specifically for GeoJSON objects. you can create a Point either directly from a Position object or passing in a longitude, latitude double array.
 
@@ -44,17 +44,17 @@ Position position = Position.fromCoordinates(-77.03655, 38.89770);
 ```
 
 ## Installation
-To start developing your application using Mapbox Java, you'll need to first determine which installation method works best for you. The SDK is fully compatible with Android using Gradle and most of the project (besides the Android dependent modules) can also be included in a generic Java project using either Gradle or Maven. All dependencies given below can be found on MavenCentral.
+To start developing your application using Mapbox Java, you'll need to first decide which installation method works best for you. The SDK is fully compatible with Android using Gradle and most of the project (besides the Android dependent modules) can also be included in a generic Java project using either Gradle or Maven. All dependencies given below can be found on MavenCentral.
 
 ### Gradle
 
 1. Start Android Studio
 2. Open up your applications `build.gradle`
-3. Ensure your projects `minSdkVersion` is at API 15 or higher
+3. Make sure your projects `minSdkVersion` is at API 15 or higher
 4. Under dependencies add a new build rule for the latest mapbox-android-services
 5. Click the Sync Project with Gradle Files near the toolbar in Studio
 
-> **Note:** If your application is close or exceeds the 65k method count limit, you can mitigate this problem by specifying only the specific Mapbox Android Service APIs instead of all of them. See the selectively compiling APIs section below.
+> **Note:** If your application is close or exceeds the 65k method count limit, you can mitigate this problem by specifying only the specific Mapbox Android Service APIs. See the selectively compiling APIs section below.
 
 ```groovy
 compile 'com.mapbox.mapboxsdk:mapbox-android-services:2.0.0'
@@ -74,7 +74,7 @@ If your project's using Maven instead of Gradle, you can add the dependency insi
 
 ### Selectively compiling APIs
 
-In previous versions of Mapbox Java prior to 2.0, you would have to compile the entire package of APIs. This in some cases, could cause Android applications to go over the 65,536 method count limit.
+In earlier versions of Mapbox Java before to 2.0, you would have to compile the entire package of APIs. This in some cases, could cause Android applications to go over the 65,536 method count limit.
 
 Starting with 2.0, you now have the option to include either the entire package of APIs (using the dependencies listed above) or you can now selectively choose which specific APIs your application needs. For example, if you only need to handle GeoJSON serialization or deserialization inside your application you only need to include the GeoJSON dependency in your project.
 

--- a/pages/mapbox-services/2.0.0/navigation.md
+++ b/pages/mapbox-services/2.0.0/navigation.md
@@ -7,17 +7,17 @@ path: /mapbox-services/2.0.0/navigation/
 
 The navigation part of Mapbox Services is built on top of our Directions API and contains logic needed to get timed navigation instructions. The calculations use the users current location and compare it to the current route the user's traversing to provide critical information at any given moment.
 
-> Currently this is only offered for Driving instructions and takes traffic into consideration by default.
+> This is only offered for Driving instructions and takes traffic into consideration by default.
 
-Much of the navigation APIs require being inside an Android application. However, we do expose some of the lower level logic inside the RouteUtils class.
+Much of the navigation APIs require being inside an Android application but we do expose some of the lower level logic inside the RouteUtils class.
 
-Ensure your Android project includes the `mapbox-android-ui` dependency to gain full access to the navigation APIs. Much of the navigation logic is handled in an Android service meaning you'll be able to continue tracking the users progress along the navigation route even when your application is not in the foreground. A few permissions are added into your application, there's no need to add the permissions by default due to manifest merging. The permissions in use are the Internet permission and the access fine location.
+Make sure your Android project includes the `mapbox-android-ui` dependency to gain full access to the navigation APIs. Much of the navigation logic is handled in an Android service meaning you'll be able to continue tracking the users progress along the navigation route even when your application is not in the foreground. A few permissions are added into your application, there's no need to add the permissions by default due to manifest merging. The permissions in use are the Internet permission and the access fine location.
 
 ## MapboxNavigation object
 
 <!-- preview -->
 
-Most of the navigation options are found inside the MapboxNavigation class including fetching the route, starting and ending the navigation session and attaching listeners for events you'd like to handle. Assign and initialize a new instance of MapboxNavigation inside your Navigation activity. When initializing, you'll need to pass in a `Context` and your Mapbox access token. Checkout the access token section in the getting started section to learn how to attain a free access token.
+Most of the navigation options are found inside the MapboxNavigation class including fetching the route, starting and ending the navigation session and attaching listeners for events you'd like to handle. Assign and initialize a new instance of MapboxNavigation inside your Navigation activity. When initializing, you'll need to pass in a `Context` and your Mapbox access token. Checkout the access token section in the getting started section to learn how to get a free access token.
 
 ```java
 MapboxNavigation navigation = new MapboxNavigation(this, MAPBOX_ACCESS_TOKEN);
@@ -27,7 +27,7 @@ MapboxNavigation navigation = new MapboxNavigation(this, MAPBOX_ACCESS_TOKEN);
 
 <!-- preview -->
 
-Navigation requires the users location in order to operate, this is done using the LocationEngine class introduced in 2.0. For detailed instructions on how to use this class, visit the LocationEngine documentation. You'll need to setup an instance of a location engine and pass it into the MapboxNavigation object.
+Navigation requires the users location to run, this is done using the LocationEngine class introduced in 2.0. For detailed instructions on how to use this class, visit the LocationEngine documentation. You'll need to setup an instance of a location engine and pass it into the MapboxNavigation object.
 
 ```java
 LocationEngine locationEngine = LostLocationEngine.getLocationEngine(this);
@@ -84,7 +84,7 @@ The RouteProgress class contains all progress information of the user along the 
 | getDurationRemainingOnStep  | The estimated time remaining till the user reaches end of current step.      |
 | getDistanceRemainingOnStep  | Measures from the users current snapped position to the last coordinate in the step.       |
 
-> This object will be null from when the NavigationService starts till the first location change occurs. Therefore if you are using this to initialize a variable, it's reasonable to check if null beforehand. Since this object is mutable, the values given can change at anytime.
+> This object will be null from when the NavigationService starts till the first location change occurs. Thus if you are using this to initialize a variable, it's reasonable to check if null beforehand. Since this object is mutable, the values given can change at anytime.
 
 ## Listeners
 
@@ -96,7 +96,7 @@ Chances are, if you are using the navigation SDK, you'll want to listen in to ev
 
 <!-- preview -->
 
-The event callback is handy for being notified when the navigation session has started, user has canceled the session, or the user has arrived at their final destination. From this information you are able to determine when to show navigation notifications, know when it's safe to stop requesting user location updates, and much more.
+The event callback is handy for being notified when the navigation session has started, user has canceled the session, or the user has arrived at their final destination. From this information you are able to decide when to show navigation notifications, know when it's safe to stop requesting user location updates, and much more.
 
 ```java
 navigation.setNavigationEventListener(new NavigationEventListener() {
@@ -116,13 +116,13 @@ Listening in to the alertLevelChange is useful for correctly getting the timing 
 | Alert level                         | Description           |
 | --------------------------- |:-------------:|
 | `DEPART_ALERT_LEVEL` | Occurs when the user first leaves the origin and shouldn't be invoked again for the rest of the navigation session. |
-| `LOW_ALERT_LEVEL` | Invoked right after the user performs a maneuver and they have started traversing along a new step. |
+| `LOW_ALERT_LEVEL` | Invoked right after the user does a maneuver and they have started traversing along a new step. |
 | `MEDIUM_ALERT_LEVEL` | Occurs when the user's x seconds away from their next maneuver. By default this is 70 seconds from next maneuver. |
-| `HIGH_ALERT_LEVEL` | Useful to know when the users about to perform the next maneuver on the route. By default this is 15 seconds. |
+| `HIGH_ALERT_LEVEL` | Useful to know when the users about to do the next maneuver on the route. By default this is 15 seconds. |
 | `ARRIVE_ALERT_LEVEL` | Occurs when the user has performed the last maneuver along the route and reached their final destination. |
 | `NONE_ALERT_LEVEL` | In a rare case when the alert level can not be determined this might be invoked. |
 
-> While the AlertLevelChange listener can help you correctly notify your users to perform an action, it relies heavily on the users current position, this means that the alert is rarely changed exactly at the correct time and might be delayed till a new location update occurs and the user is within the alerts threshold.
+> While the AlertLevelChange listener can help you correctly tell your users to do an action, it relies heavily on the users current position, this means that the alert is rarely changed exactly at the correct time and might be delayed till a new location update occurs and the user is within the alerts threshold.
 
 ```java
 navigation.setAlertLevelChangeListener(new AlertLevelChangeListener() {
@@ -156,7 +156,7 @@ navigation.setAlertLevelChangeListener(new AlertLevelChangeListener() {
 
 <!-- preview -->
 
-Similar to listening into user location changes, this listener's invoked every time the user's location changes but provides an updated RouteProgress object. This listener is strong encouraged to use since you can typically update most of your application's user interface. An example of this would be if you are displaying the users current progress till they need to perform the next maneuver, every time this listeners invoked, you are able to update your view with the new information from RouteProgress.
+Like listening into user location changes, this listener's invoked every time the user's location changes but provides an updated RouteProgress object. This listener is strong encouraged to use since you can typically update most of your application's user interface. An example of this would be if you are displaying the users current progress till they need to do the next maneuver, every time this listeners invoked, you are able to update your view with the new information from RouteProgress.
 
 Besides receiving information about the route progress, the callback also provides you with the users current location which can provide their current speed, bearing, etc. If you have snapping to the route enabled, the location object will be updated to provide the snapped coordinates.
 
@@ -179,4 +179,4 @@ Not implemented in SDK yet.
 
 <!-- preview -->
 
-The RouteUtils class can be found in the mapbox-java-services module and provides many of the methods used for calculations done in the RouteProgress object. Examples of this are getting the total route distance left till the user reaches their destination. If you would like to perform these calculations on your own or would like the change the behavior of navigation, you can directly call these methods and handle the calculations yourself.
+The RouteUtils class can be found in the mapbox-java-services module and provides many of the methods used for calculations done in the RouteProgress object. Examples of this are getting the total route distance left till the user reaches their destination. If you would like to do these calculations on your own or would like the change the behavior of navigation, you can directly call these methods and handle the calculations yourself.

--- a/pages/mapbox-services/2.0.0/telemetry.md
+++ b/pages/mapbox-services/2.0.0/telemetry.md
@@ -10,9 +10,9 @@ The telemetry library includes a bunch of utilities that you can use in your pro
 ## PermissionsManager
 If your Android project is built targeting API level 23 or higher, your application will need to request permission during runtime. Handling this directly in your activity produces a bunch of boilerplate and can oftentimes be hard to get correct. That's where the PermissionsManager comes into play. With the PermissionsManager, you can check if the user has granted location permission and request permissions if the user hasn't granted them yet.
 
-You'll notice that once you have setup your permission manager, you will still need to override your activities `onRequestPermissionsResult` and call the permissionsManagers identical method.
+You'll notice that once you have setup your permission manager, you will still need to override your activities `onRequestPermissionsResult` and call the permissionsManagers same method.
 
-> **Note:** The PermissionsManager can be used for requesting additional permissions and not just location.
+> **Note:** The PermissionsManager can be used for requesting additional permissions and not only location.
 
 ```java
 permissionsManager = new PermissionsManager(<a new PermissionsListener>);
@@ -30,7 +30,7 @@ int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
 ### PermissionsListener
 The permissionsListener needs to also be setup and passed into the PermissionsManager constructor. You'll notice that it overrides two methods, `onExplanationNeeded` and `onPermissionResult`. an explanation isn't required but strongly encouraged to allow the user to understand why you are requesting this permission.
 
-The permission result is invoked once the user decided whether or not to allow or deny the permission. A boolean value is given which you can use to write an if statement. Both cases should be handled appropriate, if they approve, proceed with your permission sensitive logic. Otherwise, if they deny, it's good to display a message to the user if the permission is required for your application to work.
+The permission result is invoked once the user decided whether to allow or deny the permission. A boolean value is given which you can use to write an if statement. Both cases should be handled correct, if they approve, continue with your permission sensitive logic. Otherwise, if they deny, it's good to display a message to the user if the permission is required for your application to work.
 
 ```java
 PermissionsListener permissionsListener = new PermissionsListener() {
@@ -51,7 +51,7 @@ PermissionsListener permissionsListener = new PermissionsListener() {
 ```
 
 ## LocationEngine
-If your application needs location information, the locationEngine can help you acquire this information while also simplifying the process and being flexible enough to use different services. The LocationEngine found in the telemetry module currently supports the following location providers:
+If your application needs location information, the locationEngine can help you get this information while also simplifying the process and being flexible enough to use different services. The LocationEngine found in the telemetry module now supports the following location providers:
 
 - [LOST](https://github.com/mapzen/lost/)
 - Google Play Services
@@ -61,7 +61,7 @@ If your application needs location information, the locationEngine can help you 
 > **Note:** if you are using our Android Maps SDK, you can also set the locationEngine equal to the `LocationSource.getLocationEngine(this);` and it will use the same location engine used by the maps SDK. This eliminates the need to create a new locationEngine from scratch.
 
 ### Getting location updates
-To start off, it's required to either include the mapbox-android-services or copy over the [LostLocationEngine class](https://github.com/mapbox/mapbox-java/blob/master/mapbox/libandroid-services/src/main/java/com/mapbox/services/android/location/LostLocationEngine.java) into your project. You'll then want to initialize a new instance of LocationEngine, activate it, and optionally add a location listener. Inside the `onConnected` you can begin requesting for location updates or wait for the appropriate time to do so.
+To start off, it's required to either include the mapbox-android-services or copy over the [LostLocationEngine class](https://github.com/mapbox/mapbox-java/blob/master/mapbox/libandroid-services/src/main/java/com/mapbox/services/android/location/LostLocationEngine.java) into your project. You'll then want to initialize a new instance of LocationEngine, activate it, and optionally add a location listener. Inside the `onConnected` you can begin requesting for location updates or wait for the proper time to do so.
 
 ```java
 LocationEngine locationEngine = LostLocationEngine.getLocationEngine(this);
@@ -82,7 +82,7 @@ locationEngine.addLocationEngineListener(new LocationEngineListener() {
 To prevent your application from having a memory leak. It is a good idea to stop requesting location updated inside your activities `onStop` method and continue requesting them in `onStart`.
 
 ### Last location
-If your application needs to quickly get a user location, you can call the `getLastLocation` which will return the users last position. You can then use the location object returned to determine the timing the location was given.
+If your application needs to quickly get a user location, you can call the `getLastLocation` which will return the users last position. You can then use the location object returned to decide the timing the location was given.
 
 > **Note:** Careful with requesting the users last location since the location has the possibility of being null.
 


### PR DESCRIPTION
This PR adds an annotations document that walks through creating and adding GL markers, polygons, and polylines. Marker views and symbol layers will be discussed in a different document. 

Am I missing any critical information @mapbox/android? would like ya'll's review before merging.

This doc should also replace the outdated [marker guide](https://www.mapbox.com/help/android-markers/) found in the `/help` repo.