### PR TITLE
Adjusting docs for MAS 2.1.1 release

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,5 +1,5 @@
 /* SDK Versions */
-export const MAS_VERSION = '2.1.0';
+export const MAS_VERSION = '2.1.1';
 export const MAP_SDK_VERSION = '5.0.1';
 export const NAVIGATION_VERSION = '0.1.1';
 export const TRAFFIC_PLUGIN_VERSION = '0.2.0';


### PR DESCRIPTION
Part of [the 2.1.1 Mapbox Android Services release](https://github.com/mapbox/mapbox-java/issues/466)

Bumped MAS version to 2.1.1 in constants file

