### PR TITLE
Map Events Doc

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -31,6 +31,29 @@
   line-height: 18px;
 }
 
+td,th {
+  text-align: left !important;
+  padding: 4px !important;
+  font-size: 12px !important;
+}
+
+th {
+    background-color: #E8EBEE;
+}
+
+td, code, pre {
+  font-weight: normal !important;
+  font-size: 12px !important;
+}
+
+
+
+
+pre {
+  background-color: #232323 !important;
+}
+
+
 /* ------------------- Limiter ------------------ */
 
 .limiter {
@@ -63,13 +86,19 @@
 
 /* ---------- Code snippet adjustments ---------- */
 
+code {
+  font-family: 'Fira Mono Medium', Monaco, monospace !important;
+  font-weight: normal;
+}
+
 code, pre {
   font-family: 'Fira Mono Medium', Monaco, monospace !important;
-  font-weight: bold !important;
+
   font-size: 12px !important;
   word-break: normal !important;
 }
 
 pre {
+  font-weight: bold;
   background-color: #232323 !important;
 }

--- a/pages/map-sdk/overview/events.md
+++ b/pages/map-sdk/overview/events.md
@@ -1,0 +1,68 @@
+---
+title: Events
+path: /map-sdk/overview/events/
+---
+# Events
+The Map SDK provides various ways to listen to map events. The majority of listeners the SDK offers are listed below, however, you'll occasionally find other listeners specific to their coresponding API which can also be used. 
+
+### Map click & long click events
+Click (tap) events can be setup through the `MapboxMap` object and invoke a callback each time the event occurs. In both cases, the callback provides a `LatLng` where the user click occurred on the map. To add a onClick listener to your map, add the following snippet inside your applications code:
+
+```java
+mapboxMap.setOnMapClickListener(new MapboxMap.OnMapClickListener() {
+  @Override
+  public void onMapClick(@NonNull LatLng point) {
+    String string = String.format(Locale.US, "User clicked at: %s", point.toString())
+    Toast.makeText(MainActivity.this, string, Toast.LENGTH_LONG).show();
+  }
+});
+```
+
+#### Convert from screen pixel
+In occassions when you need to know the corresponding location on the screen where the user gesture occurred, you can convert the LatLng point to screen pixels. The MapboxMap object provides the `Projection` from the map which allows you to convert between `LatLng` coordinates to screen pixel using `mapboxMap.getProjection().toScreenLocation(<LatLng>);`. The reverse can be done when you have a screen location in pixels and need to convert it to a corisponding `LatLng` object.
+
+A frequent usecase for converting the values between `LatLng` and pixel coordinates is when you'd like to query a map layer or source in order to, for example, determine whether or not the users clicked on a POI. You can read more on how to do this in the [Query map features]() documentation.
+
+### Camera change events
+The maps camera represents the view looking down on the maps flat plane. In almost all cases, you'll be interacting with the camera to adjust the maps starting zoom and position. The user also has the ability to manipulate the camera by performing gestures on the map such as pinch to zoom, two finger scroll to tilt, and single finger move to adjust the position.
+
+The Map SDK provides a handful of camera change listeners which can be used to be notified of any or specific camera movements. Different camera listeners are provided to determine if the camera movement was caused by a user gesture, built-in API animations, or a developer-controlled movement. The snippet below shows the various camera listeners avaliable:
+
+```java
+mapboxMap.setOnCameraMoveStartedistener(new MapboxMap.OnCameraMoveStartedListener() {
+
+  private final String[] REASONS = {"REASON_API_GESTURE", "REASON_DEVELOPER_ANIMATION", "REASON_API_ANIMATION"};
+
+  @Override
+  public void onCameraMoveStarted(int reason) {
+    String string = String.format(Locale.US, "OnCameraMoveStarted: %s", REASONS[reason - 1])
+    Toast.makeText(MainActivity.this, string, Toast.LENGTH_LONG).show();
+  }
+});
+
+mapboxMap.setOnCameraMoveListener(new MapboxMap.OnCameraMoveListener() {
+  @Override
+  public void onCameraMove() {
+    Toast.makeText(MainActivity.this, "onCameraMove", Toast.LENGTH_LONG).show();
+  }
+});
+
+mapboxMap.setOnCameraMoveCancelListener(new MapboxMap.OnCameraMoveCanceledListener() {
+  @Override
+  public void onCameraMoveCanceled() {
+    Toast.makeText(MainActivity.this, "onCameraMoveCanceled", Toast.LENGTH_LONG).show();
+  }
+});
+
+mapboxMap.setOnCameraIdleListener(new MapboxMap.OnCameraIdleListener() {
+  @Override
+  public void onCameraIdle() {
+    Toast.makeText(MainActivity.this, "onCameraIdle", Toast.LENGTH_LONG).show();
+  }
+});
+```
+
+
+### Marker and info window events
+
+### Map change events

--- a/pages/map-sdk/overview/events.md
+++ b/pages/map-sdk/overview/events.md
@@ -3,10 +3,10 @@ title: Events
 path: /map-sdk/overview/events/
 ---
 # Events
-The Map SDK provides various ways to listen to map events. The majority of listeners the SDK offers are listed below; however, you'll occasionally find other listeners specific to their corresponding API inside other overview documents.
+The Map SDK provides various ways to listen to map events. The majority of listeners that the SDK offers are listed below. However, you'll occasionally find other listeners specific to their corresponding API inside other overview documents.
 
 ### Map click & long click events
-Click (tap) events can be setup through the `MapboxMap` object and invoke a callback each time the event occurs. In both cases, the callback provides a `LatLng` where the user click occurred on the map. To add an onClick listener to your map, insert the following snippet inside your application's code:
+Click (tap) events can be set up through the `MapboxMap` object and invoke a callback each time that the event occurs. In both cases, the callback provides a `LatLng` of where the user click occurred on the map. To add an onClick listener to your map, insert the following snippet inside your application's code:
 
 ```java
 mapboxMap.setOnMapClickListener(new MapboxMap.OnMapClickListener() {
@@ -24,7 +24,7 @@ In occasions when you need to know the corresponding location on the screen wher
 A common use case for converting the values between `LatLng` and pixel coordinates is when you'd like to query a map layer or source to, for example, determine whether or not the users clicked on a POI. You can read more on how to do this in the [Query map features]() documentation.
 
 ### Camera change events
-The maps camera represents the view looking down on the maps flat plane. In almost all cases, you'll be interacting with the camera to adjust the maps starting zoom and position. The user also can manipulate the camera by performing gestures on the map such as pinch to zoom, two-finger scroll to tilt, and single finger move to adjust the position.
+The map's camera represents the view looking down on the maps flat plane. In almost all cases, you'll be interacting with the camera to adjust the map's starting zoom and target position. The user also can manipulate the camera by performing gestures on the map such as pinch-to-zoom, two-finger scroll to tilt, and single finger moves to adjust the position.
 
 The Map SDK provides a handful of camera change listeners which can notify you of any or specific camera movements. Different camera listeners are given to determine if the camera movement was caused by a user gesture, built-in API animations, or a developer-controlled movement. The snippet below shows the various camera listeners available:
 
@@ -63,7 +63,7 @@ mapboxMap.setOnCameraIdleListener(new MapboxMap.OnCameraIdleListener() {
 ```
 
 ### On fling & on scroll events
-Besides the camera change listeners, the MapboxMap object allows you to listen into when the user scrolls or flings the map. A scroll event occurs when the user drags a single finger across the screen causing the camera position to change. A similar action from the user will cause the `onFling` callback to be invoked, but the user performs the gesture with more momentum. Only one of these events will be fired once when the user performs the particular gesture.
+Besides the camera change listeners, the `MapboxMap` object allows you to listen into when the user scrolls or flings the map. A scroll event occurs when the user drags a single finger across the screen causing the camera position to change. A similar action from the user will cause the `onFling` callback to be invoked, but the user performs the gesture with more momentum. Only one of these events will be fired once when the user performs the particular gesture.
 
 ```java
 mapboxMap.setOnScrollListener(new MapboxMap.OnScrollListener() {
@@ -82,9 +82,9 @@ mapboxMap.setOnFlingListener(new MapboxMap.OnFlingListener() {
 ```
 
 ### Marker and info window events
-The Maps SDK provides a handy listener for capturing when a user taps on a marker. By default, all markers come with an onMarkerClick event listener for displaying and hiding info windows. You can override this default event listener and set your own with the setOnMarkerClickListener method.
+The Maps SDK provides a handy listener for capturing when a user taps on a marker. By default, all markers come with an onMarkerClick event listener for displaying and hiding info windows. You can override this default event listener and set your own with the `setOnMarkerClickListener` method.
 
-To display a toast message with the clicked marker’s title, listen for a click event with setOnMarkerClickListener and finally call Toast.makeText(). To prevent displaying a toast message and an info window at the same time, return true at the end:
+To display a toast message with the clicked marker’s title, listen for a click event with `setOnMarkerClickListener` and finally call Toast.makeText(). To prevent displaying a toast message and an info window at the same time, return true at the end:
 
 ```java
 mapboxMap.setOnMarkerClickListener(new MapboxMap.OnMarkerClickListener() {
@@ -113,7 +113,7 @@ mapboxMap.setOnInfoWindowClickListener(new MapboxMap.OnInfoWindowClickListener()
 ### Map change events
 The map view goes through a series of events while building/changing the map. The `OnMapChangedListener` provided can be used to notify you when one or multiple events occur you're interested in. This includes knowing when the map starts and finishes loading the map style or when frames are finished rendering.
 
-Instead of adding the listener through the `MapboxMap` object, the listeners added using the `MapView`, `mapView.addOnMapChangedListener(OnMapChangedListener());`. When a when a new map change occurs, the `onMapChanged` callbacks invoked which provides the constant, as an integer, as the parameter which you can then use to match up with one of the constants listed in the table below.
+Instead of adding the listener through the `MapboxMap` object, the listeners added using the `MapView`, `mapView.addOnMapChangedListener(OnMapChangedListener());`. When a new map change occurs, the `onMapChanged` callback is invoked. This provides the constant, as an integer, as the parameter which you can then use to match up with one of the constants listed in the table below.
 
 | MapChange Constants                       | Description |
 |-------------------------------------------|--------|
@@ -134,4 +134,4 @@ Instead of adding the listener through the `MapboxMap` object, the listeners add
 | `DID_FINISH_LOADING_STYLE`                  | Triggered when a style has finished loading. |
 | `SOURCE_DID_CHANGE`                         | Triggered when a source attribution changes. |
 
-When the event occurred you were interested in, and you no longer need to listen in to the map change events, `mapView.removeOnMapChangedListener(mapChangeListener)` can be used to remove the listener.
+When the event that you were interested in actually occurs and you no longer need to listen to the map change events, `mapView.removeOnMapChangedListener(mapChangeListener)` can be used to remove the listener.

--- a/pages/map-sdk/overview/events.md
+++ b/pages/map-sdk/overview/events.md
@@ -3,10 +3,10 @@ title: Events
 path: /map-sdk/overview/events/
 ---
 # Events
-The Map SDK provides various ways to listen to map events. The majority of listeners the SDK offers are listed below, however, you'll occasionally find other listeners specific to their coresponding API which can also be used. 
+The Map SDK provides various ways to listen to map events. The majority of listeners the SDK offers are listed below; however, you'll occasionally find other listeners specific to their corresponding API inside other overview documents.
 
 ### Map click & long click events
-Click (tap) events can be setup through the `MapboxMap` object and invoke a callback each time the event occurs. In both cases, the callback provides a `LatLng` where the user click occurred on the map. To add a onClick listener to your map, add the following snippet inside your applications code:
+Click (tap) events can be setup through the `MapboxMap` object and invoke a callback each time the event occurs. In both cases, the callback provides a `LatLng` where the user click occurred on the map. To add an onClick listener to your map, insert the following snippet inside your application's code:
 
 ```java
 mapboxMap.setOnMapClickListener(new MapboxMap.OnMapClickListener() {
@@ -19,14 +19,14 @@ mapboxMap.setOnMapClickListener(new MapboxMap.OnMapClickListener() {
 ```
 
 #### Convert from screen pixel
-In occassions when you need to know the corresponding location on the screen where the user gesture occurred, you can convert the LatLng point to screen pixels. The MapboxMap object provides the `Projection` from the map which allows you to convert between `LatLng` coordinates to screen pixel using `mapboxMap.getProjection().toScreenLocation(<LatLng>);`. The reverse can be done when you have a screen location in pixels and need to convert it to a corisponding `LatLng` object.
+In occasions when you need to know the corresponding location on the screen where the user gesture occurred, you can convert the LatLng point to screen pixels. The MapboxMap object provides the `Projection` from the map which allows you to convert between `LatLng` coordinates to screen pixel using `mapboxMap.getProjection().toScreenLocation(<LatLng>);`. The reverse is available when you have a screen location in pixels and need to convert it to a corresponding `LatLng` object.
 
-A frequent usecase for converting the values between `LatLng` and pixel coordinates is when you'd like to query a map layer or source in order to, for example, determine whether or not the users clicked on a POI. You can read more on how to do this in the [Query map features]() documentation.
+A common use case for converting the values between `LatLng` and pixel coordinates is when you'd like to query a map layer or source to, for example, determine whether or not the users clicked on a POI. You can read more on how to do this in the [Query map features]() documentation.
 
 ### Camera change events
-The maps camera represents the view looking down on the maps flat plane. In almost all cases, you'll be interacting with the camera to adjust the maps starting zoom and position. The user also has the ability to manipulate the camera by performing gestures on the map such as pinch to zoom, two finger scroll to tilt, and single finger move to adjust the position.
+The maps camera represents the view looking down on the maps flat plane. In almost all cases, you'll be interacting with the camera to adjust the maps starting zoom and position. The user also can manipulate the camera by performing gestures on the map such as pinch to zoom, two-finger scroll to tilt, and single finger move to adjust the position.
 
-The Map SDK provides a handful of camera change listeners which can be used to be notified of any or specific camera movements. Different camera listeners are provided to determine if the camera movement was caused by a user gesture, built-in API animations, or a developer-controlled movement. The snippet below shows the various camera listeners avaliable:
+The Map SDK provides a handful of camera change listeners which can notify you of any or specific camera movements. Different camera listeners are given to determine if the camera movement was caused by a user gesture, built-in API animations, or a developer-controlled movement. The snippet below shows the various camera listeners available:
 
 ```java
 mapboxMap.setOnCameraMoveStartedistener(new MapboxMap.OnCameraMoveStartedListener() {
@@ -42,7 +42,7 @@ mapboxMap.setOnCameraMoveStartedistener(new MapboxMap.OnCameraMoveStartedListene
 
 mapboxMap.setOnCameraMoveListener(new MapboxMap.OnCameraMoveListener() {
   @Override
-  public void onCameraMove() {
+  public void onCameraMove() {  
     Toast.makeText(MainActivity.this, "onCameraMove", Toast.LENGTH_LONG).show();
   }
 });
@@ -62,7 +62,76 @@ mapboxMap.setOnCameraIdleListener(new MapboxMap.OnCameraIdleListener() {
 });
 ```
 
+### On fling & on scroll events
+Besides the camera change listeners, the MapboxMap object allows you to listen into when the user scrolls or flings the map. A scroll event occurs when the user drags a single finger across the screen causing the camera position to change. A similar action from the user will cause the `onFling` callback to be invoked, but the user performs the gesture with more momentum. Only one of these events will be fired once when the user performs the particular gesture.
+
+```java
+mapboxMap.setOnScrollListener(new MapboxMap.OnScrollListener() {
+  @Override
+  public void onScroll() {
+    Toast.makeText(MainActivity.this, "onScroll", Toast.LENGTH_LONG).show();
+  }
+});
+
+mapboxMap.setOnFlingListener(new MapboxMap.OnFlingListener() {
+  @Override
+  public void onFling() {
+    Toast.makeText(MainActivity.this, "onFling", Toast.LENGTH_LONG).show();
+  }
+});
+```
 
 ### Marker and info window events
+The Maps SDK provides a handy listener for capturing when a user taps on a marker. By default, all markers come with an onMarkerClick event listener for displaying and hiding info windows. You can override this default event listener and set your own with the setOnMarkerClickListener method.
+
+To display a toast message with the clicked marker’s title, listen for a click event with setOnMarkerClickListener and finally call Toast.makeText(). To prevent displaying a toast message and an info window at the same time, return true at the end:
+
+```java
+mapboxMap.setOnMarkerClickListener(new MapboxMap.OnMarkerClickListener() {
+  @Override
+  public boolean onMarkerClick(@NonNull Marker marker) {
+    Toast.makeText(MainActivity.this, marker.getTitle(), Toast.LENGTH_LONG).show();
+    return true;
+  }
+});
+```
+
+In a similar case, the info window offers a handful of listeners for being notified when an info windows clicked, long clicked, or when a user closes the window.
+
+```java
+mapboxMap.setOnInfoWindowLongClickListener(OnInfoWindowLongClickListener);
+mapboxMap.setOnInfoWindowCloseListener(OnInfoWindowCloseListener);
+
+mapboxMap.setOnInfoWindowClickListener(new MapboxMap.OnInfoWindowClickListener() {
+  @Override
+  public boolean onInfoWindowClick(@NonNull Marker marker) {
+    return false;
+  }
+});
+```
 
 ### Map change events
+The map view goes through a series of events while building/changing the map. The `OnMapChangedListener` provided can be used to notify you when one or multiple events occur you're interested in. This includes knowing when the map starts and finishes loading the map style or when frames are finished rendering.
+
+Instead of adding the listener through the `MapboxMap` object, the listeners added using the `MapView`, `mapView.addOnMapChangedListener(OnMapChangedListener());`. When a when a new map change occurs, the `onMapChanged` callbacks invoked which provides the constant, as an integer, as the parameter which you can then use to match up with one of the constants listed in the table below.
+
+| MapChange Constants                       | Description |
+|-------------------------------------------|--------|
+| `REGION_WILL_CHANGE`                        | This event is triggered whenever the currently displayed map region is about to change without an animation. |
+| `REGION_WILL_CHANGE_ANIMATED`               | This event is triggered whenever the currently displayed map region is about to change with an animation. |
+| `REGION_IS_CHANGING`                        | This event is triggered whenever the currently displayed map region is changing. |
+| `REGION_DID_CHANGE`                         | This event is triggered whenever the currently displayed map region finished changing without an animation. |
+| `REGION_DID_CHANGE_ANIMATED`                | This event is triggered whenever the currently displayed map region finished changing with an animation. |
+| `WILL_START_LOADING_MAP`                    | This event is triggered when the map is about to start loading a new map style. |
+| `DID_FINISH_LOADING_MAP`                    | This is triggered when the map has successfully loaded a new map style. |
+| `DID_FAIL_LOADING_MAP`                      | This event is triggered when the map has failed to load a new map style. |
+| `WILL_START_RENDERING_FRAME`                | This event is triggered when the map will start rendering a frame. |
+| `DID_FINISH_RENDERING_FRAME`                | This event is triggered when the map finished rendering a frame. |
+| `DID_FINISH_RENDERING_FRAME_FULLY_RENDERED` | This event is triggered when the map finished rendering the frame fully. |
+| `WILL_START_RENDERING_MAP`                  | This event is triggered when the map will start rendering the map. |
+| `DID_FINISH_RENDERING_MAP`                  | This event is triggered when the map finished rendering the map. |
+| `DID_FINISH_RENDERING_MAP_FULLY_RENDERED`   | This event is triggered when the map is fully rendered. |
+| `DID_FINISH_LOADING_STYLE`                  | Triggered when a style has finished loading. |
+| `SOURCE_DID_CHANGE`                         | Triggered when a source attribution changes. |
+
+When the event occurred you were interested in, and you no longer need to listen in to the map change events, `mapView.removeOnMapChangedListener(mapChangeListener)` can be used to remove the listener.


### PR DESCRIPTION
Closes https://github.com/mapbox/android-docs/issues/59

This document is intended to walk through the various map events developers can listen to. @tobrun @Guardiola31337 Am I missing any events worth mentioning in this doc? I currently list:

- click and long click
- camera change events (Updated for 5.1 APIs)
- marker and info window events
- map change events

cc: @mapbox/android 