### PR TITLE
Always point to the latest MAS API reference

### DIFF
--- a/pages/_template.jsx
+++ b/pages/_template.jsx
@@ -110,13 +110,13 @@ class MainLayout extends React.Component {
     {includes(this.props.location.pathname, '/mapbox-services/') ? <PopoverTrigger content={
       <div className={'flex-parent wmin180 pb12 flex-parent--column'}>
         <strong className={'color-gray-light p6 txt-mm'}>Javadoc</strong>
-          <a href={prefixLink('/api/mapbox-java/libjava-core/2.1.0/index.html')} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-java-core</a>
-          <a href={prefixLink('/api/mapbox-java/libjava-geojson/2.1.0/index.html')} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-java-geojson</a>
-          <a href={prefixLink('/api/mapbox-java/libjava-services/2.1.0/index.html')} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-java-services</a>
-          <a href={prefixLink('/api/mapbox-java/libjava-services-rx/2.1.0/index.html')} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-java-services-rx</a>
-          <a href={prefixLink('/api/mapbox-java/libandroid-services/2.1.0/index.html')} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-android-services</a>
-          <a href={prefixLink('/api/mapbox-java/libandroid-telemetry/2.1.0/index.html')} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-android-telemetry</a>
-          <a href={prefixLink('/api/mapbox-java/libandroid-ui/2.1.0/index.html')} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-android-ui</a>
+          <a href={prefixLink(`/api/mapbox-java/libjava-core/${constants.MAS_VERSION}/index.html`)} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-java-core</a>
+          <a href={prefixLink(`/api/mapbox-java/libjava-geojson/${constants.MAS_VERSION}/index.html`)} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-java-geojson</a>
+          <a href={prefixLink(`/api/mapbox-java/libjava-services/${constants.MAS_VERSION}/index.html`)} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-java-services</a>
+          <a href={prefixLink(`/api/mapbox-java/libjava-services-rx/${constants.MAS_VERSION}/index.html`)} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-java-services-rx</a>
+          <a href={prefixLink(`/api/mapbox-java/libandroid-services/${constants.MAS_VERSION}/index.html`)} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-android-services</a>
+          <a href={prefixLink(`/api/mapbox-java/libandroid-telemetry/${constants.MAS_VERSION}/index.html`)} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-android-telemetry</a>
+          <a href={prefixLink(`/api/mapbox-java/libandroid-ui/${constants.MAS_VERSION}/index.html`)} className={`transition txt-bold color-gray-dark pl6 bg-transparent txt-s`}>mapbox-android-ui</a>
       </div>
       }
       respondsToHover={true}


### PR DESCRIPTION
Use a global constant to determine the API reference URLs.

Blocked by #101.

/cc @langsmith @cammace