### PR TITLE
Added json file

### DIFF
--- a/files/mapbox-raster-v8.json
+++ b/files/mapbox-raster-v8.json
@@ -1,0 +1,17 @@
+{
+  "version": 8,
+  "sources": {
+    "simple-tiles": {
+      "type": "raster",
+      "url": "mapbox://mapbox.streets",
+      "tileSize": 256
+    }
+  },
+  "layers": [
+    {
+      "id": "simple-tiles",
+      "type": "raster",
+      "source": "simple-tiles"
+    }
+  ]
+}


### PR DESCRIPTION
This pr adds a raster tile json file into this repo. It's the same file that lived in the `android-sdk` repo. I'm doing this because an example in the demo app references the `android-sdk` repo in the raster tile style url.
<img width="722" alt="screen shot 2017-06-23 at 10 28 29 am" src="https://user-images.githubusercontent.com/4394910/27493593-11a803bc-57ff-11e7-95ba-1d8ae3006ce5.png">
<img width="770" alt="screen shot 2017-06-23 at 10 28 26 am" src="https://user-images.githubusercontent.com/4394910/27493594-11ac65c4-57ff-11e7-965f-e25aaa722518.png">

 I've opened a separate branch/pr in the demo app repo that changes the lines to `"https://www.mapbox.com/android-docs/files/mapbox-raster-v8.json"`

Let me know if there's a different/better way to fix the demo app example and take `android-sdk`'s depreciation into account. 