### PR TITLE
Fixed broken link to maps sdk overview

### DIFF
--- a/src/pages/plugins/overview/index.md
+++ b/src/pages/plugins/overview/index.md
@@ -34,7 +34,7 @@ Mapbox Plugins build on top of the [Map SDK](/android-docs/map-sdk/overview/gett
 
 ## Install a plugin
 
-By using a plugin, you also include the Android Map SDK which means that you'll need to setup your project to use the Map SDK if you haven't already. Head over to the [Map SDK Getting Started](/android-docs/map-sdk/overview/getting-started/) documentation to learn more. The example below shows how to install the Traffic Plugin, but the process is identical for other plugins.
+By using a plugin, you also include the Android Map SDK which means that you'll need to setup your project to use the Map SDK if you haven't already. Head over to the [Map SDK Getting Started](/android-docs/map-sdk/overview) documentation to learn more. The example below shows how to install the Traffic Plugin, but the process is identical for other plugins.
 
 Note that depending on the plugin you add, there might be required permissions and additional setup steps. You'll find more information on whether or not more configuration steps are involved when looking at the specific plugin documentation.
 


### PR DESCRIPTION
This pr fixes broken link in [the Plugins overview page](https://www.mapbox.com/android-docs/plugins/overview/)


<img width="660" alt="screen shot 2017-11-20 at 10 08 51 am" src="https://user-images.githubusercontent.com/4394910/32999058-d58bbe58-cdda-11e7-8d0b-203260eb1a02.png">
