### PR TITLE
Maps SDK overview cleanup

### DIFF
--- a/src/pages/map-sdk/overview/index.md
+++ b/src/pages/map-sdk/overview/index.md
@@ -28,7 +28,7 @@ prependJs:
   - "import { Floater } from '../../../components/floater';"
   - "import { MAP_SDK_VERSION } from '../../../constants';"
 ---
-The Mapbox Maps SDK for Android is an open source toolset for displaying maps inside of your Android application. [Mapbox's demo app on the Google Play Store](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo&hl=en) includes many examples of how to use Mapbox Maps. Various pages in this documentation reference examples in the demo app.
+The Mapbox Maps SDK for Android is an open source toolset for displaying maps inside of your Android application. [Mapbox's demo app on the Google Play Store](https://play.google.com/store/apps/details?id=com.mapbox.mapboxandroiddemo&hl=en) includes many examples of how to use the Mapbox Maps SDK for Android. Various pages in this documentation reference the demo app's examples as well.
 
 ## Install the Maps SDK
 
@@ -41,19 +41,17 @@ The Mapbox Maps SDK for Android is an open source toolset for displaying maps in
   />
 }}
 
-Before starting to develop your application with the Maps SDK, you'll need to add the SDK as a dependency. You can find the following dependency given below in the MavenCentral repository. While this document shows how to install the SDK through gradle, we also offer support for [Fabric](https://fabric.io/kits/android/mapbox/install).
-
-While we show how to insert the stable version of the SDK inside your project, you can also use the nightly build/snapshot or the beta version, if one is available. Find more information about how to do this inside the project’s [GitHub repository](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/android/#readme).
+Before starting to develop your application with the Maps SDK, you'll need to add the SDK as a dependency. You can find the following dependency given below in the MavenCentral repository. Although this document shows you how to insert the stable version of the Maps SDK inside of your project, you can also use the nightly build (i.e. SNAPSHOT) or the beta version, if one is available. Find more information about how to do this inside the project’s [GitHub repository](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/android/#readme).
 
 If your application is close or exceeds the 65k method count limit, you can mitigate this problem by enabling ProGuard inside your application. ProGuard directives are included in the Android dependencies to preserve the required classes. You can also shrink the file APK file size by making use of APK splitting.
 
 ### 1. Add the dependency
 
-1. Start Android Studio
-2. Open up your application's `build.gradle`
-3. Make sure that your project's `minSdkVersion` is at API 14 or higher
-4. Under dependencies, add a new build rule for the latest `mapbox-android-sdk`
-5. Click the Sync Project with Gradle Files near the toolbar in Studio.
+1. Start Android Studio.
+2. Open up your application's `build.gradle` file.
+3. Make sure that your project's `minSdkVersion` is at API 14 or higher.
+4. Under dependencies, add a new `implementation` dependency line for the latest `mapbox-android-sdk`.
+5. Find the `File` in the toolbar and then clik on `Sync Project with Gradle Files`.
 
 ```groovy
 repositories {
@@ -67,7 +65,13 @@ dependencies {
 
 ### 2. Get an access token
 
-If you don't have a Mapbox account, sign up for one [here](https://www.mapbox.com/signup/), then navigate to your [Account page](https://www.mapbox.com/account/) and copy your **default public token** to your clipboard. After you've added the Maps SDK as a dependency inside your Android project, open the `string.xml` file, create a new string, and paste the access token. Then to pass this into the Maps SDK, you'll want to place the access token inside of your application's `onCreate()` method.
+If you don't have a Mapbox account, sign up for one [here](https://www.mapbox.com/signup/), and then navigate to your [Account page](https://www.mapbox.com/account/). Copy your **default public token** to your clipboard. After you've added the Maps SDK as a dependency inside of your Android project, open the `R.strings.xml` file, create a new String resource, and paste the access token. 
+
+```xml
+<string name="mapbox_access_token">PASTE_YOUR_ACCESS_TOKEN_HERE</string>
+```
+
+Then to pass this into the Maps SDK, you'll want to place the access token inside of your application's `onCreate()` method.
 
 ```java
 public class MyApplication extends Application {
@@ -77,14 +81,14 @@ public class MyApplication extends Application {
     super.onCreate();
 
     // Mapbox Access token
-    Mapbox.getInstance(getApplicationContext(), "<your access token>");
+    Mapbox.getInstance(getApplicationContext(), getString(R.string.mapbox_access_token));
   }
 }
 ```
 
 ### 3. Setup permissions
 
-Starting in 5.0, we are making use of the Manifest merge feature to reduce the need to include any Maps SDK required things inside of your application's manifest file. You'll need to add _either_ the Fine **or** Coarse location permission if you plan to display a user's location on the map or get the user's location information. The user location permission should also be checked during runtime using the PermissionManager.
+Starting with the 5.0 version of the Maps SDK, we are making use of the Manifest merge feature to reduce the need to include any Maps SDK required things inside of your application's manifest file. You'll need to add _either_ the Fine **or** Coarse location permission if you plan to display a user's location on the map or get the user's location information. The user location permission should also be checked during runtime using the [PermissionManager](https://www.mapbox.com/android-docs/core/overview/#permissionsmanager).
 
 ```xml
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -92,7 +96,7 @@ Starting in 5.0, we are making use of the Manifest merge feature to reduce the n
 
 ### 4. Add a map
 
-Open the activity Java file you'd like to include the map in and add the code below to the file.
+Open the Java file of the activity where you'd like to include the map in and add the code below to the file.
 
 ```java
 private MapView mapView;
@@ -112,11 +116,9 @@ protected void onCreate(Bundle savedInstanceState) {
     }
   });
 }
-
-  // Add required Lifecycle methods listed in next section
 ```
 
-Open the acitvities layout file and add the map view within your layout.
+Open the acitvity's XML layout file and add the `mapView` within your layout.
 
 ```xml
 <com.mapbox.mapboxsdk.maps.MapView
@@ -128,7 +130,7 @@ Open the acitvities layout file and add the map view within your layout.
 
 ### 5. Lifecycle methods
 
-The MapView contains its own lifecycle methods for managing Android's OpenGL lifecycle, which must be called directly from the containing Activity. In order for your app to correctly call the MapView's lifecycle methods, you must override the following lifecycle methods in the Activity that contains the MapView and call the respective MapView method. For example, your onStart() method should look like this:
+The `MapView` contains its own lifecycle methods for managing Android's OpenGL lifecycle, which must be called directly from the containing Activity. In order for your app to correctly call the MapView's lifecycle methods, you must override the following lifecycle methods in the Activity that contains the MapView and call the respective MapView method. For example, your onStart() method should look like this:
 
 ```java
 @Override
@@ -162,9 +164,9 @@ onDestroy();
   />
 }}
 
-You must include the Mapbox wordmark and attribution notice on any map that uses the Mapbox Maps SDK for Android. We provide an Attribution layout that includes all required information and can be customized either in xml or using the `UiSettings` object.
+You must include the Mapbox wordmark and attribution notice on any map that uses the Mapbox Maps SDK for Android. We provide an attribution layout that includes all required information and can be customized either in xml or using the `UiSettings` object.
 
-You may adjust the position of the Mapbox wordmark and attribution notice, but they must stay visible on the map. You may also change the background and text color of the attribution notice to best match your design aesthetics, but all information must be  legible.
+You may adjust the position of the Mapbox wordmark and attribution notice, but they must stay visible on the map. You may also change the background and text color of the attribution notice to best match your design aesthetics, but all information must be legible.
 
 You may not otherwise alter the Mapbox wordmark or text attribution notice. If you wish to move or to remove the Mapbox wordmark, please [contact our sales team](https://www.mapbox.com/contact/sales/) to discuss options available under our Enterprise plans.
 


### PR DESCRIPTION
This pr does some housekeeping cleanup of the main landing page (maps sdk overview).

Removed Fabric mention because we're no longer supporting it.