### PR TITLE
Update product dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1407,27 +1407,12 @@
       }
     },
     "@mapbox/react-popover-trigger": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/react-popover-trigger/-/react-popover-trigger-0.3.4.tgz",
-      "integrity": "sha1-i/HFpIJzMlx2myFfdMPTk40mva8=",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@mapbox/react-popover-trigger/-/react-popover-trigger-0.5.6.tgz",
+      "integrity": "sha512-T9XT6DFhtTRaSon4YqXz0lSvIhIFtuH2C42kRSqDr5hFt458crabpTg5X2M2U+iHM4IHHjHp4S182k+eXN9Idg==",
       "requires": {
-        "@mapbox/react-popover": "^0.4.0",
+        "@mapbox/react-popover": "^0.6.5",
         "hoverintent": "^2.0.0"
-      },
-      "dependencies": {
-        "@mapbox/react-popover": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/@mapbox/react-popover/-/react-popover-0.4.0.tgz",
-          "integrity": "sha1-yYQih5vDJq9nS++bQQYC4qGDyUA=",
-          "requires": {
-            "@mapbox/query-selector-contains-node": "^1.0.0",
-            "debounce": "^1.0.2",
-            "focus-trap": "^2.3.0",
-            "prefix": "^1.0.0",
-            "react-displace": "^2.3.0",
-            "xtend": "^4.0.1"
-          }
-        }
       }
     },
     "@mapbox/react-simple-surveyor": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@mapbox/appropriate-images-react": "^1.0.0",
     "@mapbox/mapbox-assembly": "^0.24.0",
     "@mapbox/page-loading-indicator": "^0.1.0",
-    "@mapbox/react-popover-trigger": "^0.3.0",
+    "@mapbox/react-popover-trigger": "^0.5.5",
     "@mapbox/react-icon": "^0.2.2",
     "@mapbox/react-code-snippet": "^0.1.21",
     "@mapbox/react-control-select": "^0.5.0",

--- a/src/components/product-menu.js
+++ b/src/components/product-menu.js
@@ -5,7 +5,7 @@ import Icon from '@mapbox/react-icon';
 import { ProductMenuDropdown } from './product-menu-dropdown';
 import { ProductNavItems } from '../data/product-nav-items.js';
 
-let popoverProps = {
+const popoverProps = {
   placement: 'bottom',
   themePopover:
     'round shadow-darken25 viewport-almost-but-not-always scroll-auto scroll-styled'
@@ -17,20 +17,9 @@ class ProductMenu extends React.PureComponent {
     product: PropTypes.string.isRequired
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      open: false
-    };
-  }
-
-  clickMore = () => {
-    popoverProps.themePopover = '';
-  };
-
-  renderMenu = () => {
+  renderMenu() {
     return <ProductMenuDropdown categories={ProductNavItems} />;
-  };
+  }
 
   onPopoverOpen = () => {
     this.setState({ open: true });

--- a/src/components/product-menu.js
+++ b/src/components/product-menu.js
@@ -5,9 +5,10 @@ import Icon from '@mapbox/react-icon';
 import { ProductMenuDropdown } from './product-menu-dropdown';
 import { ProductNavItems } from '../data/product-nav-items.js';
 
-const popoverProps = {
+let popoverProps = {
   placement: 'bottom',
-  themePopover: 'round shadow-darken25 h480 scroll-auto'
+  themePopover:
+    'round shadow-darken25 viewport-almost-but-not-always scroll-auto scroll-styled'
 };
 
 class ProductMenu extends React.PureComponent {
@@ -16,9 +17,20 @@ class ProductMenu extends React.PureComponent {
     product: PropTypes.string.isRequired
   };
 
-  renderMenu() {
-    return <ProductMenuDropdown categories={ProductNavItems} />;
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false
+    };
   }
+
+  clickMore = () => {
+    popoverProps.themePopover = '';
+  };
+
+  renderMenu = () => {
+    return <ProductMenuDropdown categories={ProductNavItems} />;
+  };
 
   onPopoverOpen = () => {
     this.setState({ open: true });

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -68,6 +68,11 @@
   max-width: 480px !important;
 }
 
+.viewport-almost-but-not-always {
+  max-height: 90vh;
+  min-height: 100%;
+}
+
 @media screen and (min-width: 800px) {
   .w480-ml {
     width: 480px !important;


### PR DESCRIPTION
Fixes #550 

@langsmith @LukasPaczos let me know what you think of this solution: 

On smaller screens (e.g. a laptop), the height of the dropdown will be almost the height of the viewport and the scroll bar will always show. 

![image](https://user-images.githubusercontent.com/10479155/42595207-69215a00-8506-11e8-96f3-85a70402b2f2.png)

On larger screens (e.g. a monitor), the menu will be expanded to its full height (as long as it's not larger than the height of the viewport). 

![screen shot 2018-07-11 at 12 27 43 pm](https://user-images.githubusercontent.com/10479155/42595281-a29e1c0a-8506-11e8-99df-57d5f7e72cd4.png)

