### PR TITLE
Adding annotation plugin docs page

### DIFF
--- a/batfish.config.js
+++ b/batfish.config.js
@@ -27,6 +27,7 @@ const productPageOrder = {
   'maps/tutorials/': ['index'],
   'plugins/overview/': [
     'index',
+    'annotation',
     'building',
     'location-layer',
     'traffic',

--- a/src/pages/maps/overview/annotations.md
+++ b/src/pages/maps/overview/annotations.md
@@ -12,7 +12,7 @@ The Mapbox Maps SDK for Android provides several different ways to mark a single
 
 {{
 <WarningNote title="Plugins to handle annotations">
-    <p>All of the writing and code snippets found below on this page are fine to use with the Mapbox Maps SDK for Android. However, we recommend that you look into the <a href="/android-docs/plugins/overview/annotation/">Mapbox Annotation Plugin for Android</a> and the <a href="/android-docs/plugins/overview/markerview/">Mapbox Markerview Plugin for Android</a> if you plan to add any icons, text, lines, or polygons to the map. These plugins simplify annotations and provide additional flexibility for displaying data.</p>
+    <p>All of the writing and code snippets found below on this page are fine to use with the Mapbox Maps SDK for Android. However, we recommend that you look into the <a href="/android-docs/plugins/overview/annotation/">Mapbox Annotation Plugin for Android</a> if you plan to add any icons, text, lines, or polygons to the map. These plugins simplify annotations and provide additional flexibility for displaying data.</p>
 </WarningNote>
 }}
 

--- a/src/pages/maps/overview/annotations.md
+++ b/src/pages/maps/overview/annotations.md
@@ -5,9 +5,16 @@ prependJs:
   - "import { Floater } from '../../../components/floater';"
   - "import CodeLanguageToggle from '../../../components/code-language-toggle';"
   - "import ToggleableCodeBlock from '../../../components/toggleable-code-block';"
+  - "import { WarningNote } from '../../../components/warning-note';" 
 ---
 
 The Mapbox Maps SDK for Android provides several different ways to mark a single point, add a line between many points, or draw a polygon. Often, these objects are drawn either on top of the map or in some cases, within the map itself. This document walks you through how to add high-level objects. 
+
+{{
+<WarningNote title="Plugins to handle annotations">
+    <p>All of the writing and code snippets found below on this page are fine to use with the Mapbox Maps SDK for Android. However, we recommend that you look into the <a href="/android-docs/plugins/overview/annotation/">Mapbox Annotation Plugin for Android</a> and the <a href="/android-docs/plugins/overview/markerview/">Mapbox Markerview Plugin for Android</a> if you plan to add any icons, text, lines, or polygons to the map. These plugins simplify annotations and provide additional flexibility for displaying data.</p>
+</WarningNote>
+}}
 
 ## Source and layer
 

--- a/src/pages/maps/overview/runtime-styling.md
+++ b/src/pages/maps/overview/runtime-styling.md
@@ -23,7 +23,7 @@ Runtime styling expands upon the design power of Mapbox Studio and exposes all t
 
 {{
 <WarningNote title="Annotation Plugin for Android">
-    <p>Sources and layers provide nimble options for customizing the look of a Mapbox map and the data displayed on the map. <a href="/android-docs/plugins/overview/annotation/">The Mapbox Annotation Plugin for Android</a>. The plugin provides a simplified system for interacting with and customizing Mapbox map layers. The plugin could be a great option for you if you would like to control your map in a different way.</p>
+    <p>Sources and layers provide nimble options for customizing the look of a Mapbox map and the data displayed on the map. The <a href="/android-docs/plugins/overview/annotation/">Mapbox Annotation Plugin for Android</a> provides a simplified system for interacting with and customizing Mapbox map layers.</p>
 </WarningNote>
 }}
 

--- a/src/pages/maps/overview/runtime-styling.md
+++ b/src/pages/maps/overview/runtime-styling.md
@@ -5,6 +5,7 @@ prependJs:
   - "import { Floater } from '../../../components/floater';"
   - "import CodeLanguageToggle from '../../../components/code-language-toggle';"
   - "import ToggleableCodeBlock from '../../../components/toggleable-code-block';"
+  - "import { WarningNote } from '../../../components/warning-note';" 
 ---
 
 {{
@@ -16,11 +17,16 @@ prependJs:
   />
 }}
 
-Using Runtime styling, you're able to dynamically change the look and feel of your map in real time. Lighten or darken the map based on the time of day, personalize icons and the colors of parks based on your users’ activity, switch languages on the fly, or bump the size of labels based on user preferences to improve legibility. Style existing map data or mix in your own – Runtime Styling is performant even with massive datasets.
+Using runtime styling, you're able to dynamically change the look and feel of your map in real time. Lighten or darken the map based on the time of day, personalize icons and the colors of parks based on your users’ activity, switch languages on the fly, or bump the size of labels based on user preferences to improve legibility. Style existing map data or mix in your own – Runtime Styling is performant even with massive datasets.
 
-Runtime styling expands upon the design power of Mapbox Studio and exposes all the same properties and attributes directly to mobile developers in our SDK.
+Runtime styling expands upon the design power of Mapbox Studio and exposes all the same properties and attributes directly to mobile developers in Mapbox Maps SDK for Android.
 
-If you'd like to add simple annotations on your map quickly, you might want to make use of the [annotations offered](https://www.mapbox.com/android-docs/map-sdk/overview/annotations/).
+{{
+<WarningNote title="Annotation Plugin for Android">
+    <p>Sources and layers provide nimble options for customizing the look of a Mapbox map and the data displayed on the map. <a href="/android-docs/plugins/overview/annotation/">The Mapbox Annotation Plugin for Android</a>. The plugin provides a simplified system for interacting with and customizing Mapbox map layers. The plugin could be a great option for you if you would like to control your map in a different way.</p>
+</WarningNote>
+}}
+
 
 ## Sources
 

--- a/src/pages/plugins/overview/annotation.md
+++ b/src/pages/plugins/overview/annotation.md
@@ -13,6 +13,8 @@ prependJs:
 
 The Mapbox Annotation Plugin simplifies the way to set and adjust the visual properties of annotations on a Mapbox map. The Mapbox Maps SDK for Android provides developers with fine-grain control over the appearance and location of map annotations. In this context, "annotations" means circles, polygons, lines, text, and icons. Using run-time and data-driven styling to create annotations can require a deep understanding of the Maps SDK and require writing more code than one might like to write. The plugin obfuscates much of the required boilerplate code.
 
+_Note: A `SymbolLayer` is the layer which is responsible for both/either map text and icons._
+
 ## Install the Annotation Plugin
 
 To start developing an application using the Annotation Plugin, you'll need to add the appropriate dependencies inside of your `build.gradle`. The Annotation Plugin dependency includes the Mapbox Maps SDK for Android. All dependencies given below can be found on MavenCentral.
@@ -67,6 +69,7 @@ mapView?.getMapAsync { mapboxMap ->
 
 />
 }} 
+
 
 ## Manager
 

--- a/src/pages/plugins/overview/annotation.md
+++ b/src/pages/plugins/overview/annotation.md
@@ -11,7 +11,7 @@ prependJs:
 
 ---
 
-The Mapbox Annotation Plugin simplifies the way to set and adjust the visual properties of annotations on a Mapbox map. The Mapbox Maps SDK for Android provides developers with fine-grain control over the appearance/location of map annotations. In this context, "annotations" means circles, polygons, lines, and text, and symbols. Using run-time and data-driven styling to create annotations can require a deep understanding of the Maps SDK and require writing more code than one might like to write. The plugin obfuscates much of the required boilerplate code.
+The Mapbox Annotation Plugin simplifies the way to set and adjust the visual properties of annotations on a Mapbox map. The Mapbox Maps SDK for Android provides developers with fine-grain control over the appearance and location of map annotations. In this context, "annotations" means circles, polygons, lines, text, and icons. Using run-time and data-driven styling to create annotations can require a deep understanding of the Maps SDK and require writing more code than one might like to write. The plugin obfuscates much of the required boilerplate code.
 
 ## Install the Annotation Plugin
 
@@ -67,7 +67,6 @@ mapView?.getMapAsync { mapboxMap ->
 
 />
 }} 
-
 
 ## Manager
 

--- a/src/pages/plugins/overview/annotation.md
+++ b/src/pages/plugins/overview/annotation.md
@@ -2,12 +2,12 @@
 title: "Annotation"
 description: "Mapbox Android Annotation Plugin"
 prependJs:
-  - |
-    import {
+  - "import {
       ANNOTATION_PLUGIN_VERSION
-    } from '../../../constants';
+    } from '../../../constants';"
   - "import CodeLanguageToggle from '../../../components/code-language-toggle';"
   - "import ToggleableCodeBlock from '../../../components/toggleable-code-block';"
+  - "import { Floater } from '../../../components/floater';"
 
 ---
 
@@ -217,8 +217,6 @@ fillManager?.create(fillOptionsList)
 />
 }}
 
-As you saw above, the `FillManager#create()` method takes in a single `FillOptions` object as a parameter. A `List<>` of `FillOptions` is also a valid parameter for the `create()` method. This is the same for all of the manager classes. `LineManager` will require a `LineOptions` class and so on.
-
 {{
   <Floater
     url="https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation"
@@ -227,3 +225,7 @@ As you saw above, the `FillManager#create()` method takes in a single `FillOptio
     text="See more usage of various option classes"
   />
 }}
+
+As you saw above, the `FillManager#create()` method takes in a single `FillOptions` object as a parameter. A `List<>` of `FillOptions` is also a valid parameter for the `create()` method. This is the same for all of the manager classes. `LineManager` will require a `LineOptions` class and so on.
+
+

--- a/src/pages/plugins/overview/annotation.md
+++ b/src/pages/plugins/overview/annotation.md
@@ -1,0 +1,227 @@
+---
+title: "Annotation"
+description: "Mapbox Android Annotation Plugin"
+prependJs:
+  - |
+    import {
+      ANNOTATION_PLUGIN_VERSION
+    } from '../../../constants';
+  - "import CodeLanguageToggle from '../../../components/code-language-toggle';"
+  - "import ToggleableCodeBlock from '../../../components/toggleable-code-block';"
+
+---
+
+The Mapbox Annotation Plugin simplifies the way to set and adjust the visual properties of annotations on a Mapbox map. The Mapbox Maps SDK for Android provides developers with fine-grain control over the appearance/location of map annotations. In this context, "annotations" means circles, polygons, lines, and text, and symbols. Using run-time and data-driven styling to create annotations can require a deep understanding of the Maps SDK and require writing more code than one might like to write. The plugin obfuscates much of the required boilerplate code.
+
+## Install the Annotation Plugin
+
+To start developing an application using the Annotation Plugin, you'll need to add the appropriate dependencies inside of your `build.gradle`. The Annotation Plugin dependency includes the Mapbox Maps SDK for Android. All dependencies given below can be found on MavenCentral.
+
+If your application is close or exceeds the 65k method count limit, you can mitigate this problem by enabling ProGuard inside your application. ProGuard directives are included in the Android dependencies to preserve the required classes.
+
+### Add the dependency
+
+1. Start Android Studio.
+2. Open up your application's `build.gradle`.
+3. Make sure that your project's `minSdkVersion` is API 14 or higher.
+4. Under dependencies, add a new build rule for the latest `mapbox-android-plugin-annotation`.
+5. Click the Sync Project with Gradle Files near the toolbar in Studio.
+
+```groovy
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annoation:{{ ANNOTATION_PLUGIN_VERSION }}'
+}
+```
+
+## Initialize the plugin
+
+The plugin includes manager classes for the various map layers available in the Mapbox Maps SDK for Android. The manager classes are explained below and their constructors only require a `MapboxMap` object. You should initialize a manager class within the `onMapReady()` method to be sure that the annotations are added to a `MapboxMap` that's completely ready.
+
+{{
+<CodeLanguageToggle id="initializing-class" />
+<ToggleableCodeBlock
+
+java={`
+mapView.getMapAsync(new OnMapReadyCallback() {
+    @Override
+    public void onMapReady(MapboxMap mapboxMap) {
+  	
+  	// Use a layer manager here
+  	
+  		
+    }
+});
+`}
+
+kotlin={`
+mapView?.getMapAsync { mapboxMap ->
+ 
+ // Use a layer manager here
+     
+}
+`}
+
+/>
+}} 
+
+
+## Manager
+
+The circle, line, fill, and symbol map layers have accompanying manager classes. Each manager class has methods for setting layer properties which are a bit less related to the visual styling. For example, `SymbolManager` adjusts the position of the `SymbolLayer`'s icon/text with methods such as `setFillTranslate()`, `setFillTranslateAnchor()`.
+
+You can also set `onClick` and `onLongClick` listeners to the type of annotations that you're adding to the map.
+
+
+| Layer type | Manager class
+| --- | --- |
+| Circle | [CircleManager](https://github.com/mapbox/mapbox-plugins-android/blob/master/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleManager.java) |
+| Line| [LineManager](https://github.com/mapbox/mapbox-plugins-android/blob/master/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineManager.java) |
+| Fill | [FillManager](https://github.com/mapbox/mapbox-plugins-android/blob/master/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillManager.java) |
+| Symbol | [SymbolManager](https://github.com/mapbox/mapbox-plugins-android/blob/master/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolManager.java) |
+
+<br>
+For example, here's how a `SymbolManager` would be used:
+
+{{
+<CodeLanguageToggle id="manager-class" />
+<ToggleableCodeBlock
+
+java={`
+// create symbol manager object
+SymbolManager symbolManager = new SymbolManager(mapboxMap);
+
+// add click listeners if desired
+symbolManager.addClickListener(symbol -> 
+
+);
+	
+symbolManager.addLongClickListener(symbol -> {
+		
+});
+
+// set non-data-driven properties, such as:
+symbolManager.setIconAllowOverlap(true);
+symbolManager.setIconTranslate(new Float[]{-4f,5f});
+symbolManager.setIconRotationAlignment(ICON_ROTATION_ALIGNMENT_VIEWPORT);
+`}
+
+kotlin={`
+// create symbol manager object
+val symbolManager = SymbolManager(mapboxMap)
+
+// add click listeners if desired
+symbolManager?.addClickListener { symbol ->
+    
+}
+
+symbolManager?.addLongClickListener { symbol ->
+    
+}
+
+// set non-data-driven properties, such as:
+symbolManager?.iconAllowOverlap = true
+symbolManager?.iconTranslate = arrayOf(-4f, 5f)
+symbolManager?.iconRotationAlignment = ICON_ROTATION_ALIGNMENT_VIEWPORT
+`}
+
+/>
+}} 
+
+{{
+  <Floater
+    url="https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation"
+    title="Manager class usage"
+    category="example"
+    text="See more usage of various manager classes"
+  />
+}}
+
+## Options
+
+The circle, line, fill, and symbol map layers _also_ have accompanying manager classes. The options classes follow the builder pattern, which allows you to set various layer properties which more related to visual styling. For example, `FillOptions` adjusts the look of `SymbolLayer` icon/text with methods such as `withFillColor()`, `withFillOpacity()`, and `withFillPattern()`.
+
+| Layer type | Option class
+| --- | --- |
+| Circle | [CircleOptions](https://github.com/mapbox/mapbox-plugins-android/blob/master/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/CircleOptions.java)
+| Line| [LineOptions](https://github.com/mapbox/mapbox-plugins-android/blob/master/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/LineOptions.java)
+| Fill | [FillOptions](https://github.com/mapbox/mapbox-plugins-android/blob/master/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/FillOptions.java)
+| Symbol | [SymbolOptions](https://github.com/mapbox/mapbox-plugins-android/blob/master/plugin-annotation/src/main/java/com/mapbox/mapboxsdk/plugins/annotation/SymbolOptions.java)
+
+{{
+<CodeLanguageToggle id="options-class" />
+<ToggleableCodeBlock
+
+java={`
+// create a fixed fill
+List<LatLng> innerLatLngs = new ArrayList<>();
+innerLatLngs.add(new LatLng(-10.733102, -3.363937));
+innerLatLngs.add(new LatLng(-19.716317, 1.754703));
+innerLatLngs.add(new LatLng(-21.085074, -15.747196));
+
+List<List<LatLng>> latLngs = new ArrayList<>();
+latLngs.add(innerLatLngs);
+      
+FillOptions fillOptions = new FillOptions()
+	.withLatLngs(latLngs)
+	.withFillColor(PropertyFactory.colorToRgbaString(Color.RED));
+fillManager.create(fillOptions);
+
+// random add fills across the globe
+List<FillOptions> fillOptionsList = new ArrayList<>();
+
+for (int i = 0; i < 20; i++) {
+	int color = Color.argb(255, random.nextInt(256), random.nextInt(256), random.nextInt(256));
+	fillOptionsList.add(new FillOptions()
+	  .withLatLngs(createRandomLatLngs())
+	  .withFillColor(PropertyFactory.colorToRgbaString(color))
+	);
+}
+
+fillManager.create(fillOptionsList);
+`}
+
+kotlin={`
+// create a fixed fill
+val innerLatLngs = ArrayList<LatLng>()
+innerLatLngs.add(LatLng(-10.733102, -3.363937))
+innerLatLngs.add(LatLng(-19.716317, 1.754703))
+innerLatLngs.add(LatLng(-21.085074, -15.747196))
+
+val latLngs = ArrayList<List<LatLng>>()
+latLngs.add(innerLatLngs)
+
+val fillOptions = FillOptions()
+	.withLatLngs(latLngs)
+	.withFillColor(PropertyFactory.colorToRgbaString(Color.RED))
+fillManager?.create(fillOptions)
+
+// random add fills across the globe
+val fillOptionsList = ArrayList<FillOptions>()
+for (i in 0..19) {
+	val color = Color.argb(255, random.nextInt(256), random.nextInt(256), random.nextInt(256))
+	fillOptionsList.add(FillOptions()
+		.withLatLngs(createRandomLatLngs())
+		.withFillColor(PropertyFactory.colorToRgbaString(color))
+	)
+}
+
+fillManager?.create(fillOptionsList)
+`}
+
+/>
+}}
+
+As you saw above, the `FillManager#create()` method takes in a single `FillOptions` object as a parameter. A `List<>` of `FillOptions` is also a valid parameter for the `create()` method. This is the same for all of the manager classes. `LineManager` will require a `LineOptions` class and so on.
+
+{{
+  <Floater
+    url="https://github.com/mapbox/mapbox-plugins-android/tree/master/app/src/main/java/com/mapbox/mapboxsdk/plugins/testapp/activity/annotation"
+    title="Manager class usage"
+    category="example"
+    text="See more usage of various option classes"
+  />
+}}

--- a/src/pages/plugins/overview/annotation.md
+++ b/src/pages/plugins/overview/annotation.md
@@ -11,9 +11,9 @@ prependJs:
 
 ---
 
-The Mapbox Annotation Plugin simplifies the way to set and adjust the visual properties of annotations on a Mapbox map. The Mapbox Maps SDK for Android provides developers with fine-grain control over the appearance and location of map annotations. In this context, "annotations" means circles, polygons, lines, text, and icons. Using runtime and data-driven styling to create annotations can require a deep understanding of the Maps SDK. The plugin obfuscates much of the required boilerplate code.
+The Mapbox Annotation Plugin simplifies the way to set and adjust the visual properties of annotations on a Mapbox map. The Mapbox Maps SDK for Android provides developers with fine-grain control over the appearance and location of map annotations. In this context, "annotations" means circles, polygons, lines, text, and icons. Using runtime and data-driven styling to create annotations can require a deep understanding of the Maps SDK. This plugin obfuscates much of the required boilerplate code.
 
-_Note: A `SymbolLayer` is the layer that is responsible for both/either map text and icons._
+_Note: A `SymbolLayer` is the layer that is responsible for both map text and icons._
 
 ## Install the Annotation Plugin
 
@@ -27,7 +27,7 @@ If your application is close or exceeds the 65k method count limit, you can miti
 2. Open up your application's `build.gradle`.
 3. Make sure that your project's `minSdkVersion` is API 14 or higher.
 4. Under dependencies, add a new build rule for the latest `mapbox-android-plugin-annotation`.
-5. Click the Sync Project with Gradle Files near the toolbar in Studio.
+5. Click the **Sync Project with Gradle Files** near the toolbar in Studio.
 
 ```groovy
 repositories {
@@ -144,7 +144,7 @@ symbolManager?.iconRotationAlignment = ICON_ROTATION_ALIGNMENT_VIEWPORT
 
 ## Options
 
-The circle, line, fill, and symbol map layers _also_ have accompanying options classes. The options classes follow the builder pattern, which allows you to set various layer properties which more related to visual styling. For example, `FillOptions` adjusts the look of `SymbolLayer` icon or text with methods such as `withFillColor()`, `withFillOpacity()`, and `withFillPattern()`.
+The circle, line, fill, and symbol map layers _also_ have accompanying options classes. The options classes follow the builder pattern, which allows you to set various layer properties that are more related to visual styling. For example, `FillOptions` adjusts the look of `SymbolLayer` icon or text with methods such as `withFillColor()`, `withFillOpacity()`, and `withFillPattern()`.
 
 | Layer type | Option class
 | --- | --- |

--- a/src/pages/plugins/overview/annotation.md
+++ b/src/pages/plugins/overview/annotation.md
@@ -11,9 +11,9 @@ prependJs:
 
 ---
 
-The Mapbox Annotation Plugin simplifies the way to set and adjust the visual properties of annotations on a Mapbox map. The Mapbox Maps SDK for Android provides developers with fine-grain control over the appearance and location of map annotations. In this context, "annotations" means circles, polygons, lines, text, and icons. Using run-time and data-driven styling to create annotations can require a deep understanding of the Maps SDK and require writing more code than one might like to write. The plugin obfuscates much of the required boilerplate code.
+The Mapbox Annotation Plugin simplifies the way to set and adjust the visual properties of annotations on a Mapbox map. The Mapbox Maps SDK for Android provides developers with fine-grain control over the appearance and location of map annotations. In this context, "annotations" means circles, polygons, lines, text, and icons. Using runtime and data-driven styling to create annotations can require a deep understanding of the Maps SDK. The plugin obfuscates much of the required boilerplate code.
 
-_Note: A `SymbolLayer` is the layer which is responsible for both/either map text and icons._
+_Note: A `SymbolLayer` is the layer that is responsible for both/either map text and icons._
 
 ## Install the Annotation Plugin
 
@@ -73,7 +73,7 @@ mapView?.getMapAsync { mapboxMap ->
 
 ## Manager
 
-The circle, line, fill, and symbol map layers have accompanying manager classes. Each manager class has methods for setting layer properties which are a bit less related to the visual styling. For example, `SymbolManager` adjusts the position of the `SymbolLayer`'s icon/text with methods such as `setFillTranslate()`, `setFillTranslateAnchor()`.
+The circle, line, fill, and symbol map layers have accompanying manager classes. Each manager class has methods for setting layer properties that are less related to the visual styling. For example, `SymbolManager` adjusts the position of the `SymbolLayer`'s icon or text with methods such as `setFillTranslate()` or `setFillTranslateAnchor()`.
 
 You can also set `onClick` and `onLongClick` listeners to the type of annotations that you're adding to the map.
 
@@ -144,7 +144,7 @@ symbolManager?.iconRotationAlignment = ICON_ROTATION_ALIGNMENT_VIEWPORT
 
 ## Options
 
-The circle, line, fill, and symbol map layers _also_ have accompanying manager classes. The options classes follow the builder pattern, which allows you to set various layer properties which more related to visual styling. For example, `FillOptions` adjusts the look of `SymbolLayer` icon/text with methods such as `withFillColor()`, `withFillOpacity()`, and `withFillPattern()`.
+The circle, line, fill, and symbol map layers _also_ have accompanying options classes. The options classes follow the builder pattern, which allows you to set various layer properties which more related to visual styling. For example, `FillOptions` adjusts the look of `SymbolLayer` icon or text with methods such as `withFillColor()`, `withFillOpacity()`, and `withFillPattern()`.
 
 | Layer type | Option class
 | --- | --- |

--- a/src/pages/plugins/overview/index.md
+++ b/src/pages/plugins/overview/index.md
@@ -8,6 +8,7 @@ prependJs:
   - "import ToggleableCodeBlock from '../../../components/toggleable-code-block';" 
   - |
     import {
+      ANNOTATION_PLUGIN_VERSION,
       TRAFFIC_PLUGIN_VERSION,
       LOCATION_LAYER_PLUGIN_VERSION,
       BUILDING_PLUGIN_VERSION,
@@ -21,6 +22,7 @@ prependJs:
   <div className="mb24">
     <OverviewHeader 
       features={[
+        "Show annotations on the map",
         "Add in-app place searching",
         "Load GeoJSON files onto the map",
         "Show user location",


### PR DESCRIPTION
Resolves #621 by adding a page for the Annotations Plugin. 

cc @mapbox/maps-android + @chloekraw 

![screencapture-localhost-8080-android-docs-plugins-overview-annotation-2018-10-08-14_27_20](https://user-images.githubusercontent.com/4394910/46634748-bca56b80-cb06-11e8-9c97-bb5f1a0a3998.png)
