### PR TITLE
order switch

### DIFF
--- a/src/pages/maps/overview/gestures.md
+++ b/src/pages/maps/overview/gestures.md
@@ -40,7 +40,7 @@ repositories {
 ```java
 // In the app build.gradle file
 dependencies {
-	implementation 'com.mapbox.mapboxsdk:mapbox-gestures-android:{{ GESTURES_SNAPSHOT_VERSION }}'
+	implementation 'com.mapbox.mapboxsdk:mapbox-android-gestures:{{ GESTURES_SNAPSHOT_VERSION }}'
 }
 ```
 


### PR DESCRIPTION
Related: https://github.com/mapbox/android-docs/pull/755

Fixed the dependency name for gesture library _snapshot_ section. Forgot to do this in #755 . 

Based on https://twitter.com/kylewiest/status/1070458676664619008 👇 

<img width="664" alt="screen shot 2018-12-05 at 3 47 43 pm" src="https://user-images.githubusercontent.com/4394910/49551694-1e831700-f8a5-11e8-8814-2c4cb1b64659.png">

