### PR TITLE
Fix last location retrieval from LocationResult in core docs

### DIFF
--- a/src/pages/core/overview/index.md
+++ b/src/pages/core/overview/index.md
@@ -215,7 +215,7 @@ private static class LocationListeningCallback
     // The LocationEngineCallback interface's method which fires when the device's location has changed.
 
     
-    Location lastLocation = result.lastLocation
+    Location lastLocation = result.getLastLocation()
 
 
     }
@@ -241,7 +241,7 @@ private val activityWeakReference: WeakReference<MainActivity>
 
     // The LocationEngineCallback interface's method which fires when the device's location has changed.	
     
-	    result.lastLocation
+	    result.getLastLocation()
 	    
 	}
 	

--- a/src/pages/core/overview/index.md
+++ b/src/pages/core/overview/index.md
@@ -215,7 +215,7 @@ private static class LocationListeningCallback
     // The LocationEngineCallback interface's method which fires when the device's location has changed.
 
     
-    Location lastLocation = result.getLastLocation()
+    Location lastLocation = result.getLastLocation();
 
 
     }


### PR DESCRIPTION
Docs list 7.1.2 as recommended version now, so old way needs to change to new way.
https://github.com/mapbox/mapbox-events-android/blob/master/liblocation/src/main/java/com/mapbox/android/core/location/LocationEngineResult.java#L65