### PR TITLE
Adding README blurb about Java/Kotlin toggles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,8 @@ i am kotlin code
 
 Language preference (Java vs. Kotlin) will persist throughout /android-docs when navigating between pages.
 
+Make sure the snippet has all of the sections. If not, the locally test side will break when you click on either the Java or Kotlin toggle. Please view [this ticket](https://github.com/mapbox/android-docs/issues/752) if you see a `Uncaught TypeError: Cannot read property 'length' of undefined` error.
+
 #### Mapbox Java SDK
 
 All overview guides for APIs in the Mapbox Java SDK should follow this format:

--- a/README.md
+++ b/README.md
@@ -75,35 +75,7 @@ The test suite will lint JavaScript as well as:
   - checks spelling
   - checks for plain language and suggests alternatives
 
-If the tests return an error or warning, follow the guidance from the test to fix. 
-
-
-### Java/Kotlin toggles
-
-Add the following snippet in a README file if you'd like to have a Java/Kotlin toggle somewhere in the documentation:
-
-```
-{{
-<CodeLanguageToggle id="UNIQUE-ID-HERE" />
-<ToggleableCodeBlock
-
-java={`
-
-JAVA CODE HERE
-
-`}
-
-kotlin={`
-
-KOTLIN CODE HERE
-
-`}
-
-/>
-}}
-```
-
-Make sure the snippet has all of the sections. If not, the locally test side will break when you click on either the Java or Kotlin toggle. Please view [this ticket](https://github.com/mapbox/android-docs/issues/752) if you see a `Uncaught TypeError: Cannot read property 'length' of undefined` error.
+If the tests return an error or warning, follow the guidance from the test to fix it. 
 
 
 ## Updating for SDK releases

--- a/README.md
+++ b/README.md
@@ -75,7 +75,36 @@ The test suite will lint JavaScript as well as:
   - checks spelling
   - checks for plain language and suggests alternatives
 
-If the tests return an error or warning, follow the guidance from the test to fix it.
+If the tests return an error or warning, follow the guidance from the test to fix. 
+
+
+### Java/Kotlin toggles
+
+Add the following snippet in a README file if you'd like to have a Java/Kotlin toggle somewhere in the documentation:
+
+```
+{{
+<CodeLanguageToggle id="UNIQUE-ID-HERE" />
+<ToggleableCodeBlock
+
+java={`
+
+JAVA CODE HERE
+
+`}
+
+kotlin={`
+
+KOTLIN CODE HERE
+
+`}
+
+/>
+}}
+```
+
+Make sure the snippet has all of the sections. If not, the locally test side will break when you click on either the Java or Kotlin toggle. Please view [this ticket](https://github.com/mapbox/android-docs/issues/752) if you see a `Uncaught TypeError: Cannot read property 'length' of undefined` error.
+
 
 ## Updating for SDK releases
 


### PR DESCRIPTION
This pr resolves https://github.com/mapbox/android-docs/issues/752 (for now) by adding a blurb to the repo's README about Java/Kotlin toggle usage and problems.